### PR TITLE
fix: Make cursor overlay click-through

### DIFF
--- a/src/ui/CursorOverlay.py
+++ b/src/ui/CursorOverlay.py
@@ -8,7 +8,8 @@ class CursorOverlay(QWidget):
         self.setWindowFlags(
             Qt.WindowType.FramelessWindowHint |
             Qt.WindowType.WindowStaysOnTopHint |
-            Qt.WindowType.Tool
+            Qt.WindowType.Tool |
+            Qt.WindowType.WindowTransparentForInput
         )
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
         self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)


### PR DESCRIPTION
The custom cursor overlay was intercepting mouse clicks, preventing users from interacting with other applications during recording.

This commit fixes the issue by adding the `Qt.WindowType.WindowTransparentForInput` flag to the `CursorOverlay` widget. This ensures that all mouse events pass through the overlay to the underlying windows.