### PR TITLE
feat: Add interactive monitor selection with visual feedback

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -54,6 +54,7 @@ from services.PptxGeneration import PptxGeneration
 from services.ProcessTextAI import ProcessTextAI
 from ui.SplashScreen import SplashScreen
 from services.ShareVideo import VideoSharingManager
+from ui.MonitorPreview import MonitorPreview
 from managers.StreamToLogger import setup_logging
 from services.FrameExtractor import FrameExtractor
 from PyQt6.QtCore import QThread, pyqtSignal, Qt
@@ -123,6 +124,7 @@ class VideoAudioManager(QMainWindow):
         # Avvia la registrazione automatica delle chiamate
         #self.teams_call_recorder.start()
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        self.monitor_preview = None
 
     def initUI(self):
         """
@@ -1734,6 +1736,15 @@ class VideoAudioManager(QMainWindow):
         self.selected_screen_index = screen_index
         for i, button in enumerate(self.screen_buttons):
             button.set_selected(i == screen_index)
+
+        if hasattr(self, 'monitor_preview') and self.monitor_preview:
+            self.monitor_preview.close()
+
+        monitors = get_monitors()
+        if screen_index < len(monitors):
+            monitor = monitors[screen_index]
+            self.monitor_preview = MonitorPreview(monitor)
+            self.monitor_preview.show()
 
 
     def browseFolderLocation(self):

--- a/src/ui/MonitorPreview.py
+++ b/src/ui/MonitorPreview.py
@@ -1,0 +1,22 @@
+from PyQt6.QtWidgets import QWidget
+from PyQt6.QtGui import QPainter, QColor, QPen
+from PyQt6.QtCore import Qt
+
+class MonitorPreview(QWidget):
+    def __init__(self, monitor):
+        super().__init__()
+        self.monitor = monitor
+        self.setWindowFlags(
+            Qt.WindowType.FramelessWindowHint |
+            Qt.WindowType.WindowStaysOnTopHint |
+            Qt.WindowType.Tool
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setGeometry(self.monitor.x, self.monitor.y, self.monitor.width, self.monitor.height)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        pen = QPen(QColor(255, 0, 0), 10)  # Red border, 10px wide
+        painter.setPen(pen)
+        painter.drawRect(self.rect())

--- a/src/ui/ScreenButton.py
+++ b/src/ui/ScreenButton.py
@@ -55,7 +55,7 @@ class ScreenButton(QWidget):
                 ScreenButton {
                     background-color: #1a93ec;
                     color: white;
-                    border: 2px solid #1a93ec;
+                    border: 3px solid red;
                     border-radius: 10px;
                 }
                 QLabel {


### PR DESCRIPTION
This commit introduces two new features to improve the user experience when selecting a monitor for screen recording:

1.  A red border is now displayed on the actual monitor that is selected. This provides clear and unambiguous feedback to the user about which screen is about to be recorded. A new `MonitorPreview` class was created for this purpose.

2.  The `ScreenButton` for the selected monitor now has a red border in the UI, making it easier to see which button is active.

These changes address the user's request for more interactive and visual feedback during the monitor selection process.