### PR TITLE
fix: Resolve NameError for undefined CursorOverlay class

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -115,9 +115,9 @@ class VideoAudioManager(QMainWindow):
         self.videoSharingManager = VideoSharingManager(self)
 
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
-        self.cursor_overlay = CursorOverlay()
-        self.cursor_overlay.hide()
-        self.load_cursor_settings()
+        # self.cursor_overlay = CursorOverlay()
+        # self.cursor_overlay.hide()
+        # self.load_cursor_settings()
         self.setDefaultAudioDevice()
 
 


### PR DESCRIPTION
This commit fixes a `NameError` that occurred because the `CursorOverlay` class was being used without being defined or imported.

The investigation revealed that `CursorOverlay` and its related method `load_cursor_settings` are not defined anywhere in the codebase, suggesting they are remnants of a removed feature.

To resolve the error, the lines of code that reference `CursorOverlay` and `load_cursor_settings` in `src/TGeniusAI.py` have been commented out.