### PR TITLE
fix: Add missing QCheckBox import in Settings.py

### DIFF
--- a/src/managers/Settings.py
+++ b/src/managers/Settings.py
@@ -4,7 +4,7 @@
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QTabWidget, QWidget,
     QDialogButtonBox, QLabel, QComboBox, QGridLayout,
-    QLineEdit, QFormLayout, QMessageBox,
+    QLineEdit, QFormLayout, QMessageBox, QCheckBox,
     QSizePolicy # Importazione necessaria per lo spaziatore
 )
 from PyQt6.QtCore import QSettings


### PR DESCRIPTION
This commit fixes a `NameError: name 'QCheckBox' is not defined` that occurred when opening the settings dialog.

The error was caused by the missing import of `QCheckBox` in `src/managers/Settings.py`. This commit adds the necessary import statement.