### PR TITLE
feat: Implement comprehensive recording and cropping improvements

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -302,6 +302,11 @@ class VideoAudioManager(QMainWindow):
         self.cutButton.setIcon(QIcon("./res/taglia.png"))
         self.cutButton.setToolTip("Taglia il video tra i segnalibri impostati")
 
+        self.cropButton = QPushButton('')
+        self.cropButton.setIcon(QIcon("./res/crop.png")) # Assuming a crop icon exists
+        self.cropButton.setToolTip("Ritaglia il video con la selezione")
+
+
         self.rewindButton = QPushButton('<< 5s')
         self.rewindButton.setIcon(QIcon("./res/rewind.png"))
         self.rewindButton.setToolTip("Riavvolgi il video di 5 secondi")
@@ -318,6 +323,7 @@ class VideoAudioManager(QMainWindow):
         self.setStartBookmarkButton.clicked.connect(self.setStartBookmark)
         self.setEndBookmarkButton.clicked.connect(self.setEndBookmark)
         self.cutButton.clicked.connect(self.cutVideoBetweenBookmarks)
+        self.cropButton.clicked.connect(self.applyCrop)
         self.rewindButton.clicked.connect(self.rewind5Seconds)
         self.forwardButton.clicked.connect(self.forward5Seconds)
         self.deleteButton.clicked.connect(self.deleteVideoSegment)
@@ -422,6 +428,7 @@ class VideoAudioManager(QMainWindow):
         playbackControlLayout.addWidget(self.setStartBookmarkButton)
         playbackControlLayout.addWidget(self.setEndBookmarkButton)
         playbackControlLayout.addWidget(self.cutButton)
+        playbackControlLayout.addWidget(self.cropButton)
         playbackControlLayout.addWidget(self.deleteButton)
 
         # Layout principale del Player Input

--- a/src/ui/VideoOverlay.py
+++ b/src/ui/VideoOverlay.py
@@ -13,19 +13,20 @@ class VideoOverlay(QWidget):
         self.crop_rect = QRect()
 
     def mousePressEvent(self, event):
-        if event.button() == Qt.MouseButton.LeftButton:
+        if event.button() == Qt.MouseButton.RightButton:
             self.rect_start = event.pos()
             self.rect_end = self.rect_start
             self.crop_rect = QRect()  # Reset
             self.update()
 
     def mouseMoveEvent(self, event):
-        if self.rect_start:
-            self.rect_end = event.pos()
-            self.update()
+        if event.buttons() & Qt.MouseButton.RightButton:
+            if self.rect_start:
+                self.rect_end = event.pos()
+                self.update()
 
     def mouseReleaseEvent(self, event):
-        if event.button() == Qt.MouseButton.LeftButton and self.rect_start:
+        if event.button() == Qt.MouseButton.RightButton and self.rect_start:
             self.rect_end = event.pos()
             self.crop_rect = QRect(self.rect_start, self.rect_end).normalized()
             self.rect_start = None


### PR DESCRIPTION
This commit delivers a set of features and fixes based on user feedback to improve the application's usability.

- **Cursor Highlight on Record:** The mouse cursor highlight is now strictly tied to the recording state. It automatically appears when recording starts and disappears when it stops, providing clear and unambiguous feedback to the user.

- **Optional Watermark:** A new "Recording" tab has been added to the settings dialog, containing a checkbox to enable or disable the watermark on video recordings. The `ScreenRecorder` has been updated to conditionally apply the watermark based on this user setting.

- **Improved Video Cropping Workflow:**
  - The video overlay now uses the **right mouse button** to draw the selection rectangle, preventing conflicts with other interactions.
  - The selection rectangle is now a clear, solid red line, improving visibility over the previous dashed line with a semi-transparent fill.
  - A dedicated "Crop" button has been added to the video player controls, providing an intuitive way to trigger the cropping functionality.