### PR TITLE
feat: Add configurable watermark settings

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -115,6 +115,8 @@ class VideoAudioManager(QMainWindow):
         self.updateViewMenu()
         self.videoSharingManager = VideoSharingManager(self)
         self.enableWatermark = False
+        self.watermarkPath = ""
+        self.watermarkSize = 0
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.cursor_overlay = CursorOverlay()
         self.cursor_overlay.hide()
@@ -129,15 +131,19 @@ class VideoAudioManager(QMainWindow):
 
     def load_recording_settings(self):
         """Carica le impostazioni per il cursore e il watermark e le salva come attributi dell'istanza."""
-        settings = QSettings("", "GeniusAI")
+        settings = QSettings("ThemaConsulting", "GeniusAI")
 
         # Leggi le impostazioni e salvale in variabili "self"
         self.show_red_dot = settings.value("cursor/showRedDot", False, type=bool)
         self.show_yellow_triangle = settings.value("cursor/showYellowTriangle", False, type=bool)
         self.enableWatermark = settings.value("recording/enableWatermark", False, type=bool)
+        self.watermarkPath = settings.value("recording/watermarkPath", "res/watermark.png")
+        self.watermarkSize = settings.value("recording/watermarkSize", 10, type=int)
+
         # Configura l'aspetto dell'overlay
         self.cursor_overlay.set_show_red_dot(self.show_red_dot)
         self.cursor_overlay.set_show_yellow_triangle(self.show_yellow_triangle)
+        self.videoOverlay.setWatermark(self.enableWatermark, self.watermarkPath, self.watermarkSize)
 
     def initUI(self):
         """
@@ -2207,7 +2213,10 @@ class VideoAudioManager(QMainWindow):
             monitor_index=monitor_index,
             audio_inputs=selected_audio_devices if not save_video_only else [],
             audio_channels=DEFAULT_AUDIO_CHANNELS if not save_video_only else 0,
-            frames=DEFAULT_FRAME_RATE, use_watermark=self.enableWatermark
+            frames=DEFAULT_FRAME_RATE,
+            use_watermark=self.enableWatermark,
+            watermark_path=self.watermarkPath,
+            watermark_size=self.watermarkSize
         )
 
         self.recorder_thread.error_signal.connect(self.showError)

--- a/src/managers/Settings.py
+++ b/src/managers/Settings.py
@@ -5,7 +5,7 @@ from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QTabWidget, QWidget,
     QDialogButtonBox, QLabel, QComboBox, QGridLayout,
     QLineEdit, QFormLayout, QMessageBox, QCheckBox,
-    QSizePolicy # Importazione necessaria per lo spaziatore
+    QSizePolicy, QPushButton, QFileDialog, QSpinBox, QHBoxLayout
 )
 from PyQt6.QtCore import QSettings
 # Importa la configurazione delle azioni e, se necessario, l'endpoint di Ollama per info
@@ -152,7 +152,30 @@ class SettingsDialog(QDialog):
         self.enableWatermark = QCheckBox()
         layout.addRow("Abilita Watermark:", self.enableWatermark)
 
+        # Add new controls for watermark path
+        self.watermarkPathEdit = QLineEdit()
+        self.watermarkPathEdit.setReadOnly(True)
+        browseButton = QPushButton("Sfoglia...")
+        browseButton.clicked.connect(self.browseWatermark)
+        pathLayout = QHBoxLayout()
+        pathLayout.addWidget(self.watermarkPathEdit)
+        pathLayout.addWidget(browseButton)
+        layout.addRow("File Watermark:", pathLayout)
+
+        # Add new control for watermark size
+        self.watermarkSizeSpinBox = QSpinBox()
+        self.watermarkSizeSpinBox.setRange(1, 100)
+        self.watermarkSizeSpinBox.setSuffix(" %")
+        layout.addRow("Dimensione Watermark:", self.watermarkSizeSpinBox)
+
+
         return widget
+
+    def browseWatermark(self):
+        # Open a file dialog to select an image
+        filePath, _ = QFileDialog.getOpenFileName(self, "Seleziona Immagine Watermark", "", "Images (*.png *.jpg *.jpeg)")
+        if filePath:
+            self.watermarkPathEdit.setText(filePath)
 
     def loadSettings(self):
         """Carica sia le API Keys che le impostazioni dei modelli."""
@@ -183,6 +206,9 @@ class SettingsDialog(QDialog):
 
         # --- Carica Impostazioni Registrazione ---
         self.enableWatermark.setChecked(self.settings.value("recording/enableWatermark", True, type=bool))
+        self.watermarkPathEdit.setText(self.settings.value("recording/watermarkPath", "res/watermark.png"))
+        self.watermarkSizeSpinBox.setValue(self.settings.value("recording/watermarkSize", 10, type=int))
+
 
     def _setComboBoxValue(self, combo_box, value):
         """Imposta il valore corrente della ComboBox se il valore è presente."""
@@ -219,6 +245,8 @@ class SettingsDialog(QDialog):
 
         # --- Salva Impostazioni Registrazione ---
         self.settings.setValue("recording/enableWatermark", self.enableWatermark.isChecked())
+        self.settings.setValue("recording/watermarkPath", self.watermarkPathEdit.text())
+        self.settings.setValue("recording/watermarkSize", self.watermarkSizeSpinBox.value())
 
         # --- Accetta e chiudi dialogo ---
         self.accept()


### PR DESCRIPTION
This commit introduces the ability for users to customize the watermark on their video recordings.

The following changes have been made:

- The settings dialog now includes options to:
  - Enable or disable the watermark.
  - Select a custom image file for the watermark.
  - Adjust the size of the watermark as a percentage of the video height.
- The video preview now displays the configured watermark, providing a live preview of how it will appear in the final recording.
- The screen recorder now uses the selected image and size to burn the watermark into the recorded video.