### PR TITLE
feat: Add watermark position and fix cursor highlight

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -117,6 +117,8 @@ class VideoAudioManager(QMainWindow):
         self.enableWatermark = False
         self.watermarkPath = ""
         self.watermarkSize = 0
+        self.watermarkPosition = "Bottom Right"
+        self.enableCursorHighlight = False
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.cursor_overlay = CursorOverlay()
         self.cursor_overlay.hide()
@@ -134,16 +136,18 @@ class VideoAudioManager(QMainWindow):
         settings = QSettings("ThemaConsulting", "GeniusAI")
 
         # Leggi le impostazioni e salvale in variabili "self"
+        self.enableCursorHighlight = settings.value("cursor/enableHighlight", False, type=bool)
         self.show_red_dot = settings.value("cursor/showRedDot", False, type=bool)
         self.show_yellow_triangle = settings.value("cursor/showYellowTriangle", False, type=bool)
         self.enableWatermark = settings.value("recording/enableWatermark", False, type=bool)
         self.watermarkPath = settings.value("recording/watermarkPath", "res/watermark.png")
         self.watermarkSize = settings.value("recording/watermarkSize", 10, type=int)
+        self.watermarkPosition = settings.value("recording/watermarkPosition", "Bottom Right")
 
         # Configura l'aspetto dell'overlay
         self.cursor_overlay.set_show_red_dot(self.show_red_dot)
         self.cursor_overlay.set_show_yellow_triangle(self.show_yellow_triangle)
-        self.videoOverlay.setWatermark(self.enableWatermark, self.watermarkPath, self.watermarkSize)
+        self.videoOverlay.setWatermark(self.enableWatermark, self.watermarkPath, self.watermarkSize, self.watermarkPosition)
 
     def initUI(self):
         """
@@ -2143,7 +2147,7 @@ class VideoAudioManager(QMainWindow):
         self.recording_segments = []  # Initialize the list to store recording segments
         self.is_paused = False
 
-        if self.show_red_dot or self.show_yellow_triangle:
+        if self.enableCursorHighlight and (self.show_red_dot or self.show_yellow_triangle):
             self.cursor_overlay.show()
 
         self.recordingTime = QTime(0, 0, 0)
@@ -2216,7 +2220,8 @@ class VideoAudioManager(QMainWindow):
             frames=DEFAULT_FRAME_RATE,
             use_watermark=self.enableWatermark,
             watermark_path=self.watermarkPath,
-            watermark_size=self.watermarkSize
+            watermark_size=self.watermarkSize,
+            watermark_position=self.watermarkPosition
         )
 
         self.recorder_thread.error_signal.connect(self.showError)

--- a/src/managers/Settings.py
+++ b/src/managers/Settings.py
@@ -168,6 +168,11 @@ class SettingsDialog(QDialog):
         self.watermarkSizeSpinBox.setSuffix(" %")
         layout.addRow("Dimensione Watermark:", self.watermarkSizeSpinBox)
 
+        # Add new control for watermark position
+        self.watermarkPositionComboBox = QComboBox()
+        self.watermarkPositionComboBox.addItems(["Top Left", "Top Right", "Bottom Left", "Bottom Right"])
+        layout.addRow("Posizione Watermark:", self.watermarkPositionComboBox)
+
 
         return widget
 
@@ -208,6 +213,7 @@ class SettingsDialog(QDialog):
         self.enableWatermark.setChecked(self.settings.value("recording/enableWatermark", True, type=bool))
         self.watermarkPathEdit.setText(self.settings.value("recording/watermarkPath", "res/watermark.png"))
         self.watermarkSizeSpinBox.setValue(self.settings.value("recording/watermarkSize", 10, type=int))
+        self.watermarkPositionComboBox.setCurrentText(self.settings.value("recording/watermarkPosition", "Bottom Right"))
 
 
     def _setComboBoxValue(self, combo_box, value):
@@ -247,6 +253,7 @@ class SettingsDialog(QDialog):
         self.settings.setValue("recording/enableWatermark", self.enableWatermark.isChecked())
         self.settings.setValue("recording/watermarkPath", self.watermarkPathEdit.text())
         self.settings.setValue("recording/watermarkSize", self.watermarkSizeSpinBox.value())
+        self.settings.setValue("recording/watermarkPosition", self.watermarkPositionComboBox.currentText())
 
         # --- Accetta e chiudi dialogo ---
         self.accept()

--- a/src/ui/VideoOverlay.py
+++ b/src/ui/VideoOverlay.py
@@ -16,11 +16,13 @@ class VideoOverlay(QWidget):
         self.watermark_path = None
         self.watermark_size = 0
         self.watermark_pixmap = None
+        self.watermark_position = "Bottom Right"
 
-    def setWatermark(self, enabled, path, size):
+    def setWatermark(self, enabled, path, size, position):
         self.watermark_enabled = enabled
         self.watermark_path = path
         self.watermark_size = size
+        self.watermark_position = position
         if self.watermark_enabled and self.watermark_path and os.path.exists(self.watermark_path):
             self.watermark_pixmap = QPixmap(self.watermark_path)
         else:
@@ -70,7 +72,17 @@ class VideoOverlay(QWidget):
 
             # Position at bottom right with a margin
             margin = 10
-            x = parent_width - scaled_pixmap.width() - margin
-            y = parent_height - scaled_pixmap.height() - margin
+            if self.watermark_position == "Top Left":
+                x = margin
+                y = margin
+            elif self.watermark_position == "Top Right":
+                x = parent_width - scaled_pixmap.width() - margin
+                y = margin
+            elif self.watermark_position == "Bottom Left":
+                x = margin
+                y = parent_height - scaled_pixmap.height() - margin
+            else:  # Bottom Right
+                x = parent_width - scaled_pixmap.width() - margin
+                y = parent_height - scaled_pixmap.height() - margin
 
             painter.drawPixmap(x, y, scaled_pixmap)


### PR DESCRIPTION
This commit introduces the ability for users to configure the position of the watermark and fixes the visibility of the cursor highlight.

The following changes have been made:

- The settings dialog now includes an option to select the watermark position (Top Left, Top Right, Bottom Left, Bottom Right).
- The video preview and the final recording now correctly place the watermark based on the selected position.
- The cursor highlight overlay is now only displayed when it is explicitly enabled in the settings.