### PR TITLE
Fix video crop selection rectangle visibility

### DIFF
--- a/src/ui/CustVideoWidget.py
+++ b/src/ui/CustVideoWidget.py
@@ -7,73 +7,10 @@ import os
 import logging
 
 class CropVideoWidget(QVideoWidget):
-    cropRectChanged = pyqtSignal(QRect)
-
+    """A simple video widget that serves as a display surface for video content."""
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setMouseTracking(True)
-        self.isSelecting = False
-        self.isPanning = False
-        self.origin = QPoint()
-        self.end = QPoint()
-        self.cropRect = QRect()
-        self.scale_factor = 1.0
-        self.translation = QPoint(0, 0)
-        self.last_mouse_pos = QPoint()
         self.setMinimumWidth(400)
-
-    def mousePressEvent(self, event):
-        if event.button() == Qt.MouseButton.RightButton:
-            self.origin = event.position().toPoint()
-            self.end = self.origin
-            self.isSelecting = True
-            self.isPanning = False
-            self.update()
-        elif event.button() == Qt.MouseButton.LeftButton and not self.isSelecting:
-            self.last_mouse_pos = event.position().toPoint()
-            self.isPanning = True
-
-    def mouseMoveEvent(self, event):
-        if self.isSelecting:
-            self.end = event.position().toPoint()
-            self.update()
-        elif self.isPanning:
-            delta = event.position().toPoint() - self.last_mouse_pos
-            self.translation += delta
-            self.last_mouse_pos = event.position().toPoint()
-            self.update()
-
-    def mouseReleaseEvent(self, event):
-        if self.isSelecting and event.button() == Qt.MouseButton.RightButton:
-            self.isSelecting = False
-            self.end = event.position().toPoint()
-            self.cropRect = QRect(self.origin, self.end).normalized()
-            self.cropRectChanged.emit(self.cropRect)
-            self.update()
-        logging.debug(self.cropRect)
-        self.isPanning = False
-
-    def wheelEvent(self, event):
-        angle_delta = event.angleDelta().y() / 8
-        steps = angle_delta / 15
-        self.scale_factor += steps * 0.1
-        self.scale_factor = max(0.1, min(self.scale_factor, 10.0))
-        self.update()
-
-    def paintEvent(self, event):
-        super().paintEvent(event)
-        painter = QPainter(self)
-        painter.scale(self.scale_factor, self.scale_factor)
-        painter.translate(self.translation / self.scale_factor)
-
-        if self.isSelecting or not self.cropRect.isNull():
-            pen = QPen(QColor(255, 0, 0), 4, Qt.PenStyle.SolidLine)  # Rettangolo rosso spesso
-            painter.setPen(pen)
-            painter.setBrush(QColor(255, 0, 0, 50))  # Colore rosso semi-trasparente
-            painter.drawRect(QRect(self.origin, self.end).normalized())
-
-    def getCropRect(self):
-        return self.cropRect.normalized()
 
 
 def main():

--- a/src/ui/VideoOverlay.py
+++ b/src/ui/VideoOverlay.py
@@ -52,16 +52,23 @@ class VideoOverlay(QWidget):
 
     def paintEvent(self, event):
         painter = QPainter(self)
-        # Imposta una penna rossa
-        pen = QPen(QColor(255, 0, 0), 2, Qt.PenStyle.SolidLine)
-        painter.setPen(pen)
-        # Se stai disegnando il rettangolo attivo
+
+        # Draw cropping rectangle
         if self.rect_start and self.rect_end:
             rect = QRect(self.rect_start, self.rect_end).normalized()
+            # Use a thicker pen and a semi-transparent brush for visibility
+            pen = QPen(QColor(255, 0, 0), 4, Qt.PenStyle.SolidLine)
+            painter.setPen(pen)
+            painter.setBrush(QColor(255, 0, 0, 50))
             painter.drawRect(rect)
         elif not self.crop_rect.isNull():
+            # Draw the final rectangle after selection is done
+            pen = QPen(QColor(255, 0, 0), 4, Qt.PenStyle.SolidLine)
+            painter.setPen(pen)
+            painter.setBrush(QColor(255, 0, 0, 50))
             painter.drawRect(self.crop_rect)
 
+        # Draw watermark
         if self.watermark_enabled and self.watermark_pixmap:
             parent_width = self.parent().width()
             parent_height = self.parent().height()


### PR DESCRIPTION
The user was unable to see the red selection rectangle when trying to crop a video. This was caused by two issues:
1.  Conflicting and redundant mouse/paint event logic in both `CropVideoWidget` and `VideoOverlay`.
2.  The `VideoOverlay` was drawing a very thin, unfilled rectangle that was practically invisible.

This commit resolves the issue by:
- Removing the unused and incorrect event handling and painting code from `CustVideoWidget.py`, simplifying the class.
- Enhancing the `paintEvent` in `VideoOverlay.py` to draw a much more visible rectangle with a thick border and a semi-transparent fill.

This centralizes the cropping UI logic in the `VideoOverlay` widget and makes the selection rectangle clearly visible to the user.