### PR TITLE
Workaround for audio repeat issue in video processing

### DIFF
--- a/src/services/VideoCropping.py
+++ b/src/services/VideoCropping.py
@@ -77,10 +77,11 @@ class CropThread(QThread):
 
             cropped_video = video.crop(x1=x1, y1=y1, x2=x2, y2=y2)
 
-            # FIX: Sincronizza la durata dell'audio con quella del video per evitare rumori alla fine
-            if cropped_video.audio:
-                audio_clip = cropped_video.audio.subclip(0, cropped_video.duration)
-                cropped_video = cropped_video.set_audio(audio_clip)
+            # WORKAROUND: This is a workaround for a persistent issue in moviepy where the audio at the end of a clip is repeated.
+            # The user reported that the last second of audio is repeated twice, so we are trimming 1.8 seconds from the end of the clip.
+            # This is not an ideal solution, but it is a direct response to the user's feedback after other, more robust solutions have failed.
+            if cropped_video.duration and cropped_video.duration > 1.8:
+                cropped_video = cropped_video.subclip(0, cropped_video.duration - 1.8)
 
             output_path = tempfile.mktemp(suffix='.mp4')
 

--- a/src/services/VideoCutting.py
+++ b/src/services/VideoCutting.py
@@ -25,14 +25,17 @@ class VideoCuttingThread(QThread):
             else:
                 raise ValueError("Formato file non supportato")
 
+            # WORKAROUND: This is a workaround for a persistent issue in moviepy where the audio at the end of a clip is repeated.
+            # The user reported that the last second of audio is repeated twice, so we are trimming 1.8 seconds from the end of the clip.
+            # This is not an ideal solution, but it is a direct response to the user's feedback after other, more robust solutions have failed.
+            end_time = self.end_time - 1.8
+            if end_time < self.start_time:
+                end_time = self.end_time
+
             # Taglia il media tra start_time e end_time
-            clip = media.subclip(self.start_time, self.end_time)
+            clip = media.subclip(self.start_time, end_time)
 
             if is_video:
-                # FIX: Sincronizza la durata dell'audio con quella del video per evitare rumori alla fine
-                if clip.audio:
-                    audio_clip = clip.audio.subclip(0, clip.duration)
-                    clip = clip.set_audio(audio_clip)
                 # Salva il file video tagliato
                 clip.write_videofile(self.output_path, codec="libx264", audio_codec="aac")
             else:


### PR DESCRIPTION
This change implements a workaround for a persistent issue in moviepy where the audio at the end of a clip is repeated. The user reported that the last second of audio is repeated twice, so this change trims 1.8 seconds from the end of the clip before writing the file.

This is not an ideal solution, but it is a direct response to the user's feedback after other, more robust solutions have failed. A detailed comment has been added to the code to explain the workaround.