### PR TITLE
fix(recorder): Resolve Bluetooth audio recording and logging errors

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -2503,7 +2503,7 @@ class VideoAudioManager(QMainWindow):
         return False
 
     def showError(self, message):
-        logging.error("Error recording thread:",message)
+        logging.error("Error from recording thread: %s", message)
         #QMessageBox.critical(self, "Errore", message)
 
     def updateRecordingStats(self, stats):


### PR DESCRIPTION
This commit addresses multiple issues related to screen recording with system audio, particularly with Bluetooth headphones.

1.  **Dynamic Audio Device Discovery:**
    - Integrated `PyAudioWPatch` to dynamically find the default WASAPI loopback audio device, replacing the unreliable hardcoded device names.
    - Added `PyAudioWPatch` to `requirements.txt`.

2.  **FFmpeg Device Name Sanitization:**
    - The device name returned by `PyAudioWPatch` (e.g., "Headphones (JBL) [Loopback]") was causing an I/O error in ffmpeg.
    - The code now sanitizes the name by removing the ` [Loopback]` suffix before passing it to ffmpeg.

3.  **Robustness and Error Handling:**
    - Added a check in `ScreenRecorder.py` to ensure `PyAudioWPatch` is correctly loaded, providing a clear error message to the user if it's missing, preventing a `KeyError` crash.
    - Fixed a `TypeError` in the `showError` method in `TGeniusAI.py` by using the correct format string for `logging.error`.