### PR TITLE
fix(recorder): Quote audio device name for ffmpeg

### DIFF
--- a/src/recorder/ScreenRecorder.py
+++ b/src/recorder/ScreenRecorder.py
@@ -82,7 +82,7 @@ class ScreenRecorder(QThread):
                     # Provide default high-quality settings for other devices
                     ffmpeg_command.extend(['-sample_rate', '44100'])
                     ffmpeg_command.extend(['-channels', '2'])
-                ffmpeg_command.extend(['-i', f'audio={audio_device}'])
+                ffmpeg_command.extend(['-i', f'audio="{audio_device}"'])
 
         # --- Build the filter_complex string and map arguments ---
         filter_complex_parts = []


### PR DESCRIPTION
The screen recorder was failing when the selected audio device had spaces or special characters in its name. This was because the device name was not being quoted in the ffmpeg command.

This change wraps the audio device name in double quotes to ensure ffmpeg parses it as a single argument, preventing the "Could not find audio only device" error.