### PR TITLE
feat: Add VB-CABLE as a selectable audio source for recording

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -111,6 +111,17 @@ class VideoAudioManager(QMainWindow):
         self.indicator_timer.timeout.connect(self.toggle_recording_indicator)
         self.is_recording = False
 
+        # Initialize attributes before UI
+        self.use_vb_cable = False
+        self.audio_device_layout = None
+        self.audio_checkbox_container = None
+        self.enableWatermark = False
+        self.watermarkPath = ""
+        self.watermarkSize = 0
+        self.watermarkPosition = "Bottom Right"
+        self.enableCursorHighlight = False
+        self.cursor_overlay = CursorOverlay()
+
         self.initUI()
         self.videoContainer.resizeEvent = self.videoContainerResizeEvent
         self.setupDockSettingsManager()
@@ -125,17 +136,11 @@ class VideoAudioManager(QMainWindow):
         self.current_audio_path = None
         self.updateViewMenu()
         self.videoSharingManager = VideoSharingManager(self)
-        self.enableWatermark = False
-        self.watermarkPath = ""
-        self.watermarkSize = 0
-        self.watermarkPosition = "Bottom Right"
-        self.enableCursorHighlight = False
+
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
-        self.cursor_overlay = CursorOverlay()
+
         self.cursor_overlay.hide()
-        self.use_vb_cable = False
-        self.audio_device_layout = None
-        self.audio_checkbox_container = None
+
         self.load_recording_settings()
         self.setDefaultAudioDevice()
         self.raw_transcription_text = ""


### PR DESCRIPTION
This change introduces an option in the settings to enable the "VB-CABLE Output" audio device as a selectable source for recording.

When this option is enabled in the preferences, the "CABLE Output" device will appear in the list of available audio inputs in the recording dock.

Additionally, when the "CABLE Output" device is selected for recording, the application will use the same special parameters (bluetooth_mode) as it does for other Bluetooth headsets, ensuring compatibility and proper recording.

The implementation includes:
- A new checkbox in the settings dialog to enable the feature.
- Dynamic updating of the audio device list based on the setting.
- Modification of the audio device discovery logic to include "CABLE" and "VoiceMeeter" devices when the setting is active.
- Update to the bluetooth mode detection to recognize the new device.

fix: Correct attribute initialization order

Moves the initialization of instance attributes in `VideoAudioManager` to before the `initUI()` call. This resolves an `AttributeError` that occurred because `initUI` (and its children) depended on attributes that were not yet created.