### PR TITLE
Fix(video): Apply watermark to videos after cutting

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -1308,7 +1308,16 @@ class VideoAudioManager(QMainWindow):
         self.progressDialog.setWindowModality(Qt.WindowModality.WindowModal)
         self.progressDialog.show()
 
-        self.cutting_thread = VideoCuttingThread(media_path, start_time, end_time, output_path)
+        self.cutting_thread = VideoCuttingThread(
+            media_path,
+            start_time,
+            end_time,
+            output_path,
+            use_watermark=self.enableWatermark,
+            watermark_path=self.watermarkPath,
+            watermark_size=self.watermarkSize,
+            watermark_position=self.watermarkPosition
+        )
         self.cutting_thread.progress.connect(self.progressDialog.setValue)
         self.cutting_thread.completed.connect(self.onCutCompleted)
         self.cutting_thread.error.connect(self.onCutError)


### PR DESCRIPTION
The watermark was previously applied during screen recording but was subsequently lost when the video was cut using the `VideoCuttingThread`. This was because the `moviepy` library used for cutting re-encodes the video without preserving the original watermark.

This change addresses the issue by:
1.  Passing the watermark settings (path, size, position) from the main application to the `VideoCuttingThread`.
2.  Implementing logic within the `VideoCuttingThread` to overlay the watermark onto the video clip *after* the cutting operation, before the final video is written.
3.  Adding validation for watermark settings and robust error handling to notify the user if the watermark cannot be applied.