### PR TITLE
feat: Add webcam picture-in-picture recording

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -119,6 +119,9 @@ class VideoAudioManager(QMainWindow):
         self.watermarkPath = ""
         self.watermarkSize = 0
         self.watermarkPosition = "Bottom Right"
+        self.record_webcam = False
+        self.webcam_device = ""
+        self.webcam_position = "Bottom Right"
         self.enableCursorHighlight = False
         self.cursor_overlay = CursorOverlay()
 
@@ -166,6 +169,11 @@ class VideoAudioManager(QMainWindow):
         self.watermarkSize = settings.value("recording/watermarkSize", 10, type=int)
         self.watermarkPosition = settings.value("recording/watermarkPosition", "Bottom Right")
         self.use_vb_cable = settings.value("recording/useVBCable", False, type=bool)
+
+        # Carica le impostazioni della webcam
+        self.record_webcam = settings.value("recording/enableWebcamPip", False, type=bool)
+        self.webcam_device = settings.value("recording/webcamDevice", "Integrated Camera")
+        self.webcam_position = settings.value("recording/webcamPipPosition", "Bottom Right")
 
         # Configura l'aspetto dell'overlay
         self.cursor_overlay.set_show_red_dot(self.show_red_dot)
@@ -2453,7 +2461,10 @@ class VideoAudioManager(QMainWindow):
             watermark_size=self.watermarkSize,
             watermark_position=self.watermarkPosition,
             bluetooth_mode=bluetooth_mode,
-            audio_volume=4.0
+            audio_volume=4.0,
+            record_webcam=self.record_webcam,
+            webcam_device=self.webcam_device,
+            webcam_position=self.webcam_position
         )
 
         self.recorder_thread.error_signal.connect(self.showError)

--- a/src/managers/Settings.py
+++ b/src/managers/Settings.py
@@ -178,6 +178,17 @@ class SettingsDialog(QDialog):
         self.useVBCableCheckBox.setToolTip("Se abilitato, mostra l'opzione VB-CABLE per la registrazione audio, utile per cuffie bluetooth.")
         layout.addRow("Abilita VB-CABLE (cuffie):", self.useVBCableCheckBox)
 
+        # --- Webcam Picture-in-Picture Settings ---
+        self.enableWebcamPip = QCheckBox()
+        layout.addRow("Abilita Webcam Picture-in-Picture:", self.enableWebcamPip)
+
+        self.webcamDeviceEdit = QLineEdit()
+        self.webcamDeviceEdit.setToolTip("Il nome esatto della webcam come riconosciuto da ffmpeg.")
+        layout.addRow("Nome Dispositivo Webcam:", self.webcamDeviceEdit)
+
+        self.webcamPipPositionComboBox = QComboBox()
+        self.webcamPipPositionComboBox.addItems(["Top Left", "Top Right", "Bottom Left", "Bottom Right"])
+        layout.addRow("Posizione Webcam PiP:", self.webcamPipPositionComboBox)
 
         return widget
 
@@ -221,6 +232,11 @@ class SettingsDialog(QDialog):
         self.watermarkPositionComboBox.setCurrentText(self.settings.value("recording/watermarkPosition", "Bottom Right"))
         self.useVBCableCheckBox.setChecked(self.settings.value("recording/useVBCable", False, type=bool))
 
+        # --- Carica Impostazioni Webcam PiP ---
+        self.enableWebcamPip.setChecked(self.settings.value("recording/enableWebcamPip", False, type=bool))
+        self.webcamDeviceEdit.setText(self.settings.value("recording/webcamDevice", "Integrated Camera"))
+        self.webcamPipPositionComboBox.setCurrentText(self.settings.value("recording/webcamPipPosition", "Bottom Right"))
+
 
     def _setComboBoxValue(self, combo_box, value):
         """Imposta il valore corrente della ComboBox se il valore è presente."""
@@ -261,6 +277,11 @@ class SettingsDialog(QDialog):
         self.settings.setValue("recording/watermarkSize", self.watermarkSizeSpinBox.value())
         self.settings.setValue("recording/watermarkPosition", self.watermarkPositionComboBox.currentText())
         self.settings.setValue("recording/useVBCable", self.useVBCableCheckBox.isChecked())
+
+        # --- Salva Impostazioni Webcam PiP ---
+        self.settings.setValue("recording/enableWebcamPip", self.enableWebcamPip.isChecked())
+        self.settings.setValue("recording/webcamDevice", self.webcamDeviceEdit.text())
+        self.settings.setValue("recording/webcamPipPosition", self.webcamPipPositionComboBox.currentText())
 
         # --- Accetta e chiudi dialogo ---
         self.accept()


### PR DESCRIPTION
This commit introduces the capability to record the screen and a webcam simultaneously, with the webcam video overlaid as a picture-in-picture (PiP) on the final output.

Key changes:
- Adds UI controls to the 'Recording' settings tab to enable/disable webcam PiP, specify the webcam device name, and select the overlay position (e.g., Top Right, Bottom Left).
- Modifies `ScreenRecorder.py` to dynamically construct an `ffmpeg` command that includes the webcam as a video input.
- Implements a robust `filter_complex` chain that scales the webcam feed and overlays it onto the screen recording in real-time. The logic correctly handles cases where both PiP and a watermark are enabled, applying them sequentially.
- Integrates the new UI settings into the main application logic, ensuring they are loaded, saved, and passed to the recorder correctly.