### PR TITLE
Feat: Add preview and edit step to PPTX generation

### DIFF
--- a/src/ui/PptxDialog.py
+++ b/src/ui/PptxDialog.py
@@ -153,8 +153,9 @@ class PptxDialog(QDialog):
 
         if image_paths:
             preview_dialog = PreviewDialog(image_paths, self)
-            # Non facciamo self.accept() qui, l'utente deve premere "Genera"
-            preview_dialog.exec()
+            if preview_dialog.exec():
+                # Se l'utente clicca "Salva" nell'anteprima, procedi con la generazione
+                self.handle_generate()
             preview_dialog.cleanup()
 
     def handle_generate(self):
@@ -177,7 +178,7 @@ class PptxDialog(QDialog):
             settings["template_path"]
         )
         # Se la creazione va a buon fine, il metodo sopra mostra già un messaggio.
-        # Possiamo chiudere il dialogo dopo la generazione.
+        # Chiudiamo il dialogo dopo la generazione.
         self.accept()
 
     def get_ai_text(self):


### PR DESCRIPTION
This change addresses an issue where presentation slides were generated empty or with incomplete content.

The previous workflow generated the presentation content from the AI model and immediately created the PPTX file, without allowing the user to review or modify the generated text. This could lead to empty or incorrect slides if the AI output was not parsed correctly.

The new implementation modifies the presentation generation dialog (`PptxDialog`) to include a multi-step process:
1. A new "Generate AI Content" button calls the AI model to produce the slide text.
2. The generated text is displayed in an editable QTextEdit widget.
3. The "Preview" and "Generate" buttons are only enabled after the content is generated.
4. These buttons now use the (potentially user-modified) text from the QTextEdit widget to create the preview images or the final PPTX file.

This ensures that the user has full control over the content before the final presentation is created.

This commit also includes a fix for a follow-up issue where slides were still incomplete due to a fragile parsing mechanism. The text-to-slide parsing logic in `PptxGeneration.createPresentationFromText` has been completely rewritten to use a robust, line-by-line, state-machine-like approach. This new parser correctly identifies "Titolo:", "Sottotitolo:", and "Contenuto:" sections, making it resilient to formatting variations from the AI.

Additionally, this commit fixes multiple issues that prevented the application from running in a standard Linux environment:
- Removed the Windows-specific `pywin32` dependency from `requirements.txt`.
- Resolved a Qt platform plugin conflict by replacing `opencv-python` with the `opencv-python-headless` package.
- Corrected inconsistent relative and absolute imports throughout the `src` module to allow the application to be run as a proper package.
- Installed missing system-level dependencies like `portaudio19-dev` and `libpulse0`.