### PR TITLE
fix: Resolve AttributeError for setPitchPreserved

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -101,9 +101,9 @@ class VideoAudioManager(QMainWindow):
 
         self.player.setAudioOutput(self.audioOutput)
         self.audioOutput.setVolume(1.0)
-        self.audioOutput.setPitchPreserved(True)
+        self.player.setPitchPreserved(True)
         self.playerOutput.setAudioOutput(self.audioOutputOutput)
-        self.audioOutputOutput.setPitchPreserved(True)
+        self.playerOutput.setPitchPreserved(True)
         self.recentFiles = []
 
         # Blinking recording indicator


### PR DESCRIPTION
This commit fixes a runtime `AttributeError` that occurred because the `setPitchPreserved` method was being called on `QAudioOutput` objects.

According to the PyQt6 API, this method belongs to the `QMediaPlayer` class. The calls have been moved to the correct objects (`self.player` and `self.playerOutput`) to resolve the error and ensure that the audio pitch is correctly preserved during playback speed changes.