### PR TITLE
Feat: Add font size and family settings for editor

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -11,7 +11,7 @@ from PyQt6.QtMultimedia import QMediaPlayer, QAudioOutput
 
 # Librerie PyQt6
 from PyQt6.QtCore import (Qt, QUrl, QEvent, QTimer, QPoint, QTime, QSettings)
-from PyQt6.QtGui import (QIcon, QAction, QDesktopServices, QImage, QPixmap)
+from PyQt6.QtGui import (QIcon, QAction, QDesktopServices, QImage, QPixmap, QFont)
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QGridLayout,
     QPushButton, QLabel, QCheckBox, QRadioButton, QLineEdit,
@@ -618,7 +618,6 @@ class VideoAudioManager(QMainWindow):
         #--------------------
 
         self.transcriptionTextArea = CustomTextEdit(self)
-        self.transcriptionTextArea.setStyleSheet("font-size: 14pt; font-family: 'Arial';")
         self.transcriptionTextArea.setPlaceholderText("La trascrizione del video apparirà qui...")
         self.transcriptionTextArea.textChanged.connect(self.handleTextChange)
         self.transcriptionTextArea.timestampDoubleClicked.connect(self.sincronizza_video)
@@ -704,7 +703,6 @@ class VideoAudioManager(QMainWindow):
         summary_layout.addWidget(summary_controls_group)
 
         self.summaryTextArea = CustomTextEdit(self)
-        self.summaryTextArea.setStyleSheet("font-size: 14pt; font-family: 'Arial';")
         self.summaryTextArea.setPlaceholderText("Il riassunto generato dall'AI apparirà qui...")
         summary_layout.addWidget(self.summaryTextArea)
 
@@ -824,6 +822,33 @@ class VideoAudioManager(QMainWindow):
 
         # Applica lo stile a tutti i dock
         self.applyStyleToAllDocks()
+
+        # Applica le impostazioni del font
+        self.apply_and_save_font_settings()
+
+        # Connetti i segnali per il cambio di font
+        self.transcriptionTextArea.fontSizeChanged.connect(self.apply_and_save_font_settings)
+        self.summaryTextArea.fontSizeChanged.connect(self.apply_and_save_font_settings)
+
+    def apply_and_save_font_settings(self, size=None):
+        """
+        Applica le impostazioni del font (famiglia e dimensione) alle aree di testo
+        e salva la dimensione se viene modificata.
+        """
+        settings = QSettings("ThemaConsulting", "GeniusAI")
+
+        font_family = settings.value("editor/fontFamily", "Arial")
+
+        if size is None:
+            font_size = settings.value("editor/fontSize", 14, type=int)
+        else:
+            font_size = size
+            settings.setValue("editor/fontSize", font_size)
+
+        font = QFont(font_family, font_size)
+
+        self.transcriptionTextArea.setFont(font)
+        self.summaryTextArea.setFont(font)
 
     def videoContainerResizeEvent(self, event):
         # When the container is resized, resize both the video widget and the overlay
@@ -1317,6 +1342,7 @@ class VideoAudioManager(QMainWindow):
         dialog = SettingsDialog(self)
         if dialog.exec():
             self.load_recording_settings()
+            self.apply_and_save_font_settings()
 
     def set_default_dock_layout(self):
 

--- a/src/managers/Settings.py
+++ b/src/managers/Settings.py
@@ -5,7 +5,8 @@ from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QTabWidget, QWidget,
     QDialogButtonBox, QLabel, QComboBox, QGridLayout,
     QLineEdit, QFormLayout, QMessageBox, QCheckBox,
-    QSizePolicy, QPushButton, QFileDialog, QSpinBox, QHBoxLayout
+    QSizePolicy, QPushButton, QFileDialog, QSpinBox, QHBoxLayout,
+    QFontComboBox
 )
 from PyQt6.QtCore import QSettings
 # Importa la configurazione delle azioni e, se necessario, l'endpoint di Ollama per info
@@ -40,6 +41,9 @@ class SettingsDialog(QDialog):
 
         # Tab per il Salvataggio
         tabs.addTab(self.createSavingSettingsTab(), "Salvataggio")
+
+        # Tab per l'Editor di Testo
+        tabs.addTab(self.createEditorSettingsTab(), "Editor")
 
         layout.addWidget(tabs)
         # --- Fine Ristrutturazione con QTabWidget ---
@@ -197,6 +201,25 @@ class SettingsDialog(QDialog):
 
         return widget
 
+    def createEditorSettingsTab(self):
+        """Crea il widget per il tab delle impostazioni dell'editor di testo."""
+        widget = QWidget()
+        layout = QFormLayout(widget)
+
+        # Controllo per la famiglia di font
+        self.fontFamilyComboBox = QFontComboBox()
+        self.fontFamilyComboBox.setToolTip("Seleziona la famiglia di caratteri per l'editor di testo.")
+        layout.addRow("Font Family:", self.fontFamilyComboBox)
+
+        # Controllo per la dimensione del font
+        self.fontSizeSpinBox = QSpinBox()
+        self.fontSizeSpinBox.setRange(6, 72)
+        self.fontSizeSpinBox.setSuffix(" pt")
+        self.fontSizeSpinBox.setToolTip("Imposta la dimensione del carattere per l'editor di testo.")
+        layout.addRow("Font Size:", self.fontSizeSpinBox)
+
+        return widget
+
     def loadSettings(self):
         """Carica sia le API Keys che le impostazioni dei modelli."""
 
@@ -232,6 +255,10 @@ class SettingsDialog(QDialog):
 
         # --- Carica Impostazioni Salvataggio ---
         self.saveWithPlaybackSpeed.setChecked(self.settings.value("saving/saveWithPlaybackSpeed", False, type=bool))
+
+        # --- Carica Impostazioni Editor ---
+        self.fontFamilyComboBox.setCurrentFont(self.settings.value("editor/fontFamily", "Arial"))
+        self.fontSizeSpinBox.setValue(self.settings.value("editor/fontSize", 14, type=int))
 
 
     def _setComboBoxValue(self, combo_box, value):
@@ -275,6 +302,10 @@ class SettingsDialog(QDialog):
 
         # --- Salva Impostazioni Salvataggio ---
         self.settings.setValue("saving/saveWithPlaybackSpeed", self.saveWithPlaybackSpeed.isChecked())
+
+        # --- Salva Impostazioni Editor ---
+        self.settings.setValue("editor/fontFamily", self.fontFamilyComboBox.currentFont().family())
+        self.settings.setValue("editor/fontSize", self.fontSizeSpinBox.value())
 
         # --- Accetta e chiudi dialogo ---
         self.accept()


### PR DESCRIPTION
This commit introduces two new features to enhance the text editor widgets (`transcriptionTextArea` and `summaryTextArea`):

1.  **Mouse Wheel Font Resizing:** Users can now hold the Ctrl key and use the mouse wheel to dynamically increase or decrease the font size in the text editors. A `fontSizeChanged` signal is emitted to persist this change in the settings.

2.  **Font Configuration in Settings:** A new "Editor" tab has been added to the application's settings dialog. This allows users to select a font family from a `QFontComboBox` and set a specific font size using a `QSpinBox`.

These settings are loaded on startup and applied immediately after changes are saved in the settings dialog, ensuring a persistent and customizable user experience. The hardcoded font styles have been removed in favor of this new, more flexible system.