### PR TITLE
feat: Add video date, markdown and summary options

### DIFF
--- a/src/managers/Settings.py
+++ b/src/managers/Settings.py
@@ -46,6 +46,9 @@ class SettingsDialog(QDialog):
         # Tab per l'Editor di Testo
         tabs.addTab(self.createEditorSettingsTab(), "Editor")
 
+        # Tab per l'Elaborazione
+        tabs.addTab(self.createProcessingSettingsTab(), "Elaborazione")
+
         layout.addWidget(tabs)
         # --- Fine Ristrutturazione con QTabWidget ---
 
@@ -262,6 +265,9 @@ class SettingsDialog(QDialog):
         self.fontFamilyComboBox.setCurrentFont(QFont(font_family))
         self.fontSizeSpinBox.setValue(self.settings.value("editor/fontSize", 14, type=int))
 
+        # --- Carica Impostazioni Elaborazione ---
+        self.integratedSummaryOnlyCheckbox.setChecked(self.settings.value("processing/integratedSummaryOnly", False, type=bool))
+
 
     def _setComboBoxValue(self, combo_box, value):
         """Imposta il valore corrente della ComboBox se il valore è presente."""
@@ -272,6 +278,16 @@ class SettingsDialog(QDialog):
             if combo_box.count() > 0:
                 combo_box.setCurrentIndex(0)
                 print(f"Attenzione: Il modello salvato '{value}' non è più disponibile per {combo_box.toolTip()}. Impostato il primo modello disponibile.")
+
+    def createProcessingSettingsTab(self):
+        widget = QWidget()
+        layout = QFormLayout(widget)
+
+        self.integratedSummaryOnlyCheckbox = QCheckBox()
+        self.integratedSummaryOnlyCheckbox.setToolTip("Se abilitato, il riassunto integrato sostituirà il testo esistente invece di essere aggiunto in coda.")
+        layout.addRow("Mostra solo riassunto integrato:", self.integratedSummaryOnlyCheckbox)
+
+        return widget
 
     def saveSettings(self):
         """Salva sia le API Keys che le impostazioni dei modelli."""
@@ -308,6 +324,9 @@ class SettingsDialog(QDialog):
         # --- Salva Impostazioni Editor ---
         self.settings.setValue("editor/fontFamily", self.fontFamilyComboBox.currentFont().family())
         self.settings.setValue("editor/fontSize", self.fontSizeSpinBox.value())
+
+        # --- Salva Impostazioni Elaborazione ---
+        self.settings.setValue("processing/integratedSummaryOnly", self.integratedSummaryOnlyCheckbox.isChecked())
 
         # --- Accetta e chiudi dialogo ---
         self.accept()

--- a/src/services/DownloadVideo.py
+++ b/src/services/DownloadVideo.py
@@ -10,7 +10,7 @@ from src.config import FFMPEG_PATH
 
 
 class DownloadThread(QThread):
-    finished = pyqtSignal(str, str, str)  # Emits path of file, video title, and language
+    finished = pyqtSignal(str, str, str, str)  # Emits path of file, video title, language and date
     error = pyqtSignal(str)
     progress = pyqtSignal(int)  # Signal for download progress
     stream_url_found = pyqtSignal(str)  # Nuovo segnale per l'URL del flusso trovato
@@ -185,7 +185,7 @@ class DownloadThread(QThread):
                 ydl.download([stream_url])
 
             # Emetti il segnale di completamento
-            self.finished.emit(output_path, base_name, "it")  # Lingua predefinita: italiano
+            self.finished.emit(output_path, base_name, "it", None)  # Lingua predefinita: italiano
 
         except Exception as e:
             self.error.emit(f"Errore durante il download del video: {str(e)}")
@@ -211,9 +211,9 @@ class DownloadThread(QThread):
                 if 'id' in info:
                     audio_file_path = os.path.join(self.temp_dir, f"{info['id']}.mp3")
                     video_title = info.get('title', 'Unknown Title')
-                    # Cerca di ottenere la lingua dai metadati del video, se presente
                     video_language = info.get('language', 'Lingua non rilevata')
-                    self.finished.emit(audio_file_path, video_title, video_language)
+                    upload_date = info.get('upload_date', None)
+                    self.finished.emit(audio_file_path, video_title, video_language, upload_date)
                 else:
                     self.error.emit("Video ID not found.")
         except Exception as e:
@@ -239,9 +239,9 @@ class DownloadThread(QThread):
                 if 'id' in info:
                     video_file_path = os.path.join(self.temp_dir, f"{info['id']}.mp4")
                     video_title = info.get('title', 'Unknown Title')
-                    # Cerca di ottenere la lingua dai metadati del video, se presente
                     video_language = info.get('language', 'Lingua non rilevata')
-                    self.finished.emit(video_file_path, video_title, video_language)
+                    upload_date = info.get('upload_date', None)
+                    self.finished.emit(video_file_path, video_title, video_language, upload_date)
                 else:
                     self.error.emit("Video ID not found.")
         except Exception as e:


### PR DESCRIPTION
This commit introduces three new features and enhancements:

1.  **Video Date Extraction:** The application now extracts the upload date for downloaded videos and saves it to the associated JSON metadata file under the `video_date` key.

2.  **Markdown Display Toggle:** A "Visualizza Markdown" (View Markdown) checkbox is now available for summaries. When checked, the summary is rendered as Markdown. When unchecked, it displays the raw text, preserving the original formatting. This is achieved by storing the raw summary text and re-rendering on toggle.

3.  **Integrated Summary Display Option:** A new setting has been added to control the behavior of the "Integrate Info" feature. Users can now choose to have the integrated summary replace the existing text entirely, rather than being appended to it.