### PR TITLE
feat: Add video date and enhance summary display options

### DIFF
--- a/src/managers/Settings.py
+++ b/src/managers/Settings.py
@@ -46,9 +46,6 @@ class SettingsDialog(QDialog):
         # Tab per l'Editor di Testo
         tabs.addTab(self.createEditorSettingsTab(), "Editor")
 
-        # Tab per l'Elaborazione
-        tabs.addTab(self.createProcessingSettingsTab(), "Elaborazione")
-
         layout.addWidget(tabs)
         # --- Fine Ristrutturazione con QTabWidget ---
 
@@ -265,9 +262,6 @@ class SettingsDialog(QDialog):
         self.fontFamilyComboBox.setCurrentFont(QFont(font_family))
         self.fontSizeSpinBox.setValue(self.settings.value("editor/fontSize", 14, type=int))
 
-        # --- Carica Impostazioni Elaborazione ---
-        self.integratedSummaryOnlyCheckbox.setChecked(self.settings.value("processing/integratedSummaryOnly", False, type=bool))
-
 
     def _setComboBoxValue(self, combo_box, value):
         """Imposta il valore corrente della ComboBox se il valore è presente."""
@@ -278,16 +272,6 @@ class SettingsDialog(QDialog):
             if combo_box.count() > 0:
                 combo_box.setCurrentIndex(0)
                 print(f"Attenzione: Il modello salvato '{value}' non è più disponibile per {combo_box.toolTip()}. Impostato il primo modello disponibile.")
-
-    def createProcessingSettingsTab(self):
-        widget = QWidget()
-        layout = QFormLayout(widget)
-
-        self.integratedSummaryOnlyCheckbox = QCheckBox()
-        self.integratedSummaryOnlyCheckbox.setToolTip("Se abilitato, il riassunto integrato sostituirà il testo esistente invece di essere aggiunto in coda.")
-        layout.addRow("Mostra solo riassunto integrato:", self.integratedSummaryOnlyCheckbox)
-
-        return widget
 
     def saveSettings(self):
         """Salva sia le API Keys che le impostazioni dei modelli."""
@@ -324,9 +308,6 @@ class SettingsDialog(QDialog):
         # --- Salva Impostazioni Editor ---
         self.settings.setValue("editor/fontFamily", self.fontFamilyComboBox.currentFont().family())
         self.settings.setValue("editor/fontSize", self.fontSizeSpinBox.value())
-
-        # --- Salva Impostazioni Elaborazione ---
-        self.settings.setValue("processing/integratedSummaryOnly", self.integratedSummaryOnlyCheckbox.isChecked())
 
         # --- Accetta e chiudi dialogo ---
         self.accept()


### PR DESCRIPTION
This commit introduces several new features and enhancements based on user feedback:

1.  **Video Date Extraction:** The application now extracts the upload date for downloaded videos and saves it to the associated JSON metadata file under the `video_date` key.

2.  **Markdown Display Toggle:** A "Visualizza Markdown" (View Markdown) checkbox now correctly toggles the summary view. When checked, the summary is rendered as Markdown. When unchecked, it displays the raw text, preserving the original formatting. The underlying logic has been fixed to prevent data loss on toggle.

3.  **Reworked Summary Switching Logic:** The "Visualizza dopo integrazione" checkbox functionality has been completely reworked. It no longer affects the transcription text area. Instead, it now switches the content of the summary text area between the standard summary (`summary_generated`) and the summary that has been integrated with video frame information (`summary_generated_integrated`).