### PR TITLE
feat: Rework summary logic and add video date

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -965,11 +965,10 @@ class VideoAudioManager(QMainWindow):
             QMessageBox.warning(self, "Attenzione", "Nessun video caricato.")
             return
 
-        # Salva il testo corrente come "prima dell'integrazione"
-        self.text_before_integration = self.transcriptionTextArea.toPlainText()
-        self.text_after_integration = ""
-        self.integrazioneToggle.setChecked(False)
-        self.integrazioneToggle.setEnabled(False)
+        # Controlla se esiste un riassunto standard
+        if not self.summary_generated or not self.summary_generated.strip():
+            QMessageBox.warning(self, "Attenzione", "È necessario generare un riassunto standard prima di poterlo integrare con le informazioni del video.")
+            return
 
         # Mostra un dialogo di progresso
         self.progressDialog = QProgressDialog("Estrazione informazioni dal video...", "Annulla", 0, 100, self)
@@ -977,12 +976,12 @@ class VideoAudioManager(QMainWindow):
         self.progressDialog.setWindowModality(Qt.WindowModality.WindowModal)
         self.progressDialog.show()
 
-        # Avvia il thread di integrazione video
+        # Avvia il thread di integrazione video usando il riassunto standard come base
         self.integration_thread = VideoIntegrationThread(
             video_path=self.videoPathLineEdit,
             num_frames=self.estrazioneFrameCountSpin.value(),
             language=self.languageComboBox.currentText(),
-            current_summary=self.text_before_integration,
+            current_summary=self.summary_generated,
             parent=self
         )
         self.integration_thread.finished.connect(self.onIntegrazioneComplete)


### PR DESCRIPTION
This commit implements several features and bug fixes based on user feedback:

1.  **Video Date Extraction:** The application now extracts the video's upload date during the download process and saves it to the associated JSON metadata file.

2.  **Markdown Display Logic:** The Markdown view toggle for summaries has been fixed to correctly preserve the raw text, preventing data loss when switching between rendered and plain text views.

3.  **Reworked Summary Integration and Display:**
    - The "Integrate Info from Video" feature now correctly uses the standard generated summary as its base text, warning the user if it's not available.
    - The "Visualizza dopo integrazione" (View after integration) checkbox now exclusively controls the summary text area. It toggles the view between the standard summary and the integrated summary.