### PR TITLE
fix: Resolve crash when rendering Markdown summaries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ requests>=2.28.0
 playwright
 google-generativeai==0.8.0
 langchain_google_genai
+Markdown

--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -7,6 +7,7 @@ import datetime
 import time
 import logging
 import json
+import markdown
 from PyQt6.QtMultimedia import QMediaPlayer, QAudioOutput
 
 # Librerie PyQt6
@@ -1378,7 +1379,12 @@ class VideoAudioManager(QMainWindow):
 
         self.summaryTextArea.blockSignals(True)
         if is_markdown:
-            self.summaryTextArea.setMarkdown(summary_text)
+            try:
+                html = markdown.markdown(summary_text)
+                self.summaryTextArea.setHtml(html)
+            except Exception as e:
+                logging.error(f"Errore durante la conversione Markdown in HTML: {e}")
+                self.summaryTextArea.setPlainText(summary_text)
         else:
             self.summaryTextArea.setPlainText(summary_text)
         self.summaryTextArea.blockSignals(False)


### PR DESCRIPTION
This commit fixes a crash that occurred when trying to render an integrated summary as Markdown.

The root cause was that the application's built-in Markdown parser could not handle the format of the AI-generated integrated summary, leading to a crash.

The fix involves:
1.  Adding the `Markdown` library to `requirements.txt` for robust Markdown-to-HTML conversion.
2.  Updating the `update_summary_view` method to use this library to safely convert summary text to HTML before displaying it. This prevents the application from crashing on malformed or complex text.