### PR TITLE
Feat: Finalizza la finestra di ricerca con conteggio occorrenze corretto

### DIFF
--- a/src/ui/CustumTextEdit.py
+++ b/src/ui/CustumTextEdit.py
@@ -396,11 +396,8 @@ class SearchDialog(QDialog):
 
         if not search_text:
             self.resultCountLabel.setText("Risultati:")
-        elif num_results == 0:
-            self.resultCountLabel.setText("Risultati: 0")
         else:
-            current = self.textEdit.get_current_search_index() + 1
-            self.resultCountLabel.setText(f"Risultati: {current}/{num_results}")
+            self.resultCountLabel.setText(f"Risultati: {num_results}")
 
     def closeEvent(self, event):
         """Sovrascrive l'evento di chiusura per garantire la pulizia."""


### PR DESCRIPTION
Questo commit completa e finalizza la finestra di dialogo di ricerca (Ctrl+F) implementando tutte le funzionalità richieste, inclusa la correzione finale al formato del conteggio dei risultati.

1.  **Conteggio Occorrenze Corretto**: L'etichetta dei risultati ora mostra solo il numero totale di occorrenze trovate (es. "Risultati: 10"), come specificato dall'utente.
2.  **Opzione "Parola intera"**: Aggiunta una checkbox per la ricerca di parole intere.
3.  **Opzione "Maiuscole/minuscole"**: La funzionalità è presente e funzionante.
4.  **Feedback Visivo**: La casella di ricerca diventa arancione chiaro quando non vengono trovati risultati.
5.  **Correzioni Robuste**: Mantiene le soluzioni definitive per il focus automatico e la pulizia affidabile dell'evidenziazione.