### PR TITLE
feat: Add fullscreen shortcut to video players

### DIFF
--- a/src/ui/CustVideoWidget.py
+++ b/src/ui/CustVideoWidget.py
@@ -1,4 +1,4 @@
-from PyQt6.QtGui import QPainter, QPen, QColor, QWheelEvent
+from PyQt6.QtGui import QPainter, QPen, QColor, QWheelEvent, QKeyEvent
 from PyQt6.QtMultimediaWidgets import QVideoWidget
 from PyQt6.QtCore import Qt, QRect, QPoint, pyqtSignal
 from PyQt6.QtWidgets import QWidget, QApplication, QVBoxLayout
@@ -11,6 +11,15 @@ class CropVideoWidget(QVideoWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setMinimumWidth(400)
+        self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
+
+    def keyPressEvent(self, event: QKeyEvent):
+        if event.key() == Qt.Key.Key_F:
+            if self.isFullScreen():
+                self.setFullScreen(False)
+            else:
+                self.setFullScreen(True)
+        super().keyPressEvent(event)
 
 
 def main():


### PR DESCRIPTION
This commit introduces a keyboard shortcut to toggle fullscreen mode for both the input and output video players. By pressing the 'f' key while a video player widget is focused, the user can now enter or exit fullscreen mode.

This was achieved by:
- Modifying the `CropVideoWidget` class in `src/ui/CustVideoWidget.py`.
- Setting the focus policy to `Qt.FocusPolicy.ClickFocus` to allow the widget to receive key presses.
- Overriding the `keyPressEvent` method to handle the 'f' key press and toggle the fullscreen state.

Since both video players are instances of `CropVideoWidget`, this change applies to both as requested.