### PR TITLE
feat: Add red circle overlay to cursor during recording

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -65,6 +65,7 @@ from src.services.FrameExtractor import FrameExtractor
 from src.services.VideoCropping import CropThread
 from PyQt6.QtCore import QThread, pyqtSignal, Qt
 from src.ui.CropDialog import CropDialog
+from src.ui.CursorOverlay import CursorOverlay
 from src.config import (get_api_key, FFMPEG_PATH, FFMPEG_PATH_DOWNLOAD, VERSION_FILE,
                     MUSIC_DIR, DEFAULT_FRAME_COUNT, DEFAULT_AUDIO_CHANNELS,
                     DEFAULT_STABILITY, DEFAULT_SIMILARITY, DEFAULT_STYLE,
@@ -368,6 +369,7 @@ class VideoAudioManager(QMainWindow):
         #self.teams_call_recorder.start()
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.monitor_preview = None
+        self.cursor_overlay = CursorOverlay()
 
     def load_recording_settings(self):
         """Carica le impostazioni per il cursore e il watermark e le salva come attributi dell'istanza."""
@@ -2922,6 +2924,8 @@ class VideoAudioManager(QMainWindow):
         return dock
 
     def startScreenRecording(self):
+        if self.show_red_dot:
+            self.cursor_overlay.show()
         self.is_recording = True
         self.indicator_timer.start(500)  # Blink every 500ms
 
@@ -3040,6 +3044,8 @@ class VideoAudioManager(QMainWindow):
         self.is_paused = False
 
     def stopScreenRecording(self):
+        if self.cursor_overlay.isVisible():
+            self.cursor_overlay.hide()
         self.is_recording = False
         self.indicator_timer.stop()
         self.recording_indicator.setVisible(False)

--- a/src/ui/CursorOverlay.py
+++ b/src/ui/CursorOverlay.py
@@ -1,0 +1,39 @@
+import sys
+from PyQt6.QtWidgets import QWidget
+from PyQt6.QtGui import QPainter, QPen, QColor, QCursor
+from PyQt6.QtCore import Qt, QTimer
+
+class CursorOverlay(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowFlags(
+            Qt.WindowType.FramelessWindowHint |
+            Qt.WindowType.WindowStaysOnTopHint |
+            Qt.WindowType.Tool
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setGeometry(0, 0, 40, 40)
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.update_position)
+        self.radius = 15
+        self.pen_width = 3
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        pen = QPen(QColor(255, 0, 0), self.pen_width)
+        painter.setPen(pen)
+        center = self.rect().center()
+        painter.drawEllipse(center, self.radius, self.radius)
+
+    def update_position(self):
+        pos = QCursor.pos()
+        self.move(pos.x() - self.width() // 2, pos.y() - self.height() // 2)
+
+    def showEvent(self, event):
+        self.timer.start(10) # Update position every 10ms
+        super().showEvent(event)
+
+    def hideEvent(self, event):
+        self.timer.stop()
+        super().hideEvent(event)


### PR DESCRIPTION
This change introduces a feature that displays a red circle around the mouse cursor during screen recording.

The circle is rendered using a transparent, borderless overlay window (`CursorOverlay`) that follows the cursor's position.

This feature can be enabled or disabled in the application settings under the 'Cursore' tab with the 'Mostra Punto Rosso' checkbox.

The overlay is shown when recording starts and hidden when it stops, ensuring it is captured in the final video.