### PR TITLE
fix: Load audio-only recordings into the output player

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -3129,18 +3129,12 @@ class VideoAudioManager(QMainWindow):
 
             message = f"Il {'file audio' if is_audio_only else 'video'} finale è stato salvato correttamente:\n{output_path}"
             QMessageBox.information(self, "File Salvato", message)
-            if is_audio_only:
-                self.loadVideo(output_path)
-            else:
-                self.loadVideoOutput(output_path)
+            self.loadVideoOutput(output_path)
         else:
             output_path = self.recording_segments[0]
             message = f"Il {'file audio' if is_audio_only else 'video'} è stato salvato correttamente:\n{output_path}"
             QMessageBox.information(self, "File Salvato", message)
-            if is_audio_only:
-                self.loadVideo(output_path)
-            else:
-                self.loadVideoOutput(output_path)
+            self.loadVideoOutput(output_path)
 
     def _is_bluetooth_mode_active(self):
         """Checks if any of the selected audio devices is a Bluetooth headset."""


### PR DESCRIPTION
This commit changes the behavior of the application to load audio-only recordings into the 'Video Player Output' dock, ensuring consistent handling of all recording types.