### PR TITLE
feat: Add temp file cleanup, bookmark menu, and UI tweaks

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -394,6 +394,7 @@ class VideoAudioManager(QMainWindow):
         self.audioOutput.setVolume(1.0)
         self.playerOutput.setAudioOutput(self.audioOutputOutput)
         self.recentFiles = []
+        self.recording_segments = []
 
         # Blinking recording indicator
         self.recording_indicator = QLabel(self)
@@ -2743,6 +2744,25 @@ class VideoAudioManager(QMainWindow):
         self.dockSettingsManager.save_settings()
         if hasattr(self, 'monitor_preview') and self.monitor_preview:
             self.monitor_preview.close()
+
+        # Pulizia dei file temporanei
+        logging.info("Pulizia dei file temporanei...")
+        for segment_path in self.recording_segments:
+            try:
+                if os.path.exists(segment_path):
+                    os.remove(segment_path)
+                    logging.info(f"Rimosso file temporaneo: {segment_path}")
+            except Exception as e:
+                logging.error(f"Impossibile rimuovere il file temporaneo {segment_path}: {e}")
+
+        try:
+            segments_file = "segments.txt"
+            if os.path.exists(segments_file):
+                os.remove(segments_file)
+                logging.info(f"Rimosso file: {segments_file}")
+        except Exception as e:
+            logging.error(f"Impossibile rimuovere il file {segments_file}: {e}")
+
         event.accept()
 
     def selectDefaultScreen(self):
@@ -3151,7 +3171,7 @@ class VideoAudioManager(QMainWindow):
         self.startRecordingButton.setEnabled(False)
         self.pauseRecordingButton.setEnabled(True)
         self.stopRecordingButton.setEnabled(True)
-        self.recording_segments = []  # Initialize the list to store recording segments
+        self.recording_segments.clear()  # Pulisce i segmenti precedenti
         self.is_paused = False
 
         self.recordingTime = QTime(0, 0, 0)
@@ -3749,9 +3769,9 @@ class VideoAudioManager(QMainWindow):
         # Creazione del menu View per la gestione della visibilità dei docks
         viewMenu = menuBar.addMenu('&View')
 
-        # Creazione del menu Effetti
-        effectsMenu = menuBar.addMenu('&Effetti')
-        self.setupEffectsMenuActions(effectsMenu)
+        # Creazione del menu Effetti (Rimosso)
+        # effectsMenu = menuBar.addMenu('&Effetti')
+        # self.setupEffectsMenuActions(effectsMenu)
 
         # Creazione del menu Workspace per i layout preimpostati
         workspaceMenu = menuBar.addMenu('&Workspace')

--- a/src/ui/CustomSlider.py
+++ b/src/ui/CustomSlider.py
@@ -1,5 +1,5 @@
-from PyQt6.QtWidgets import QSlider, QStyleOptionSlider
-from PyQt6.QtGui import QPainter, QColor, QBrush, QFont
+from PyQt6.QtWidgets import QSlider, QStyleOptionSlider, QMenu
+from PyQt6.QtGui import QPainter, QColor, QBrush, QFont, QAction
 from PyQt6.QtCore import Qt
 
 class CustomSlider(QSlider):
@@ -77,6 +77,37 @@ class CustomSlider(QSlider):
             self.sliderMoved.emit(value)
             self.sliderPressed.emit()
         super().mousePressEvent(event)
+
+    def get_bookmark_at(self, pos):
+        """Restituisce l'indice del bookmark alla posizione data."""
+        if self.maximum() == 0:
+            return None
+        for i, (start, end) in enumerate(self.bookmarks):
+            x_start = int(start / self.maximum() * self.width())
+            x_end = int(end / self.maximum() * self.width())
+            if x_start <= pos.x() <= x_end:
+                return i
+        return None
+
+    def contextMenuEvent(self, event):
+        """Gestisce il menu contestuale per i bookmark."""
+        context_menu = QMenu(self)
+
+        # Azione per resettare tutti i bookmark
+        reset_all_action = QAction("Resetta tutti i bookmark", self)
+        reset_all_action.triggered.connect(self.resetBookmarks)
+        context_menu.addAction(reset_all_action)
+
+        # Azione per rimuovere un bookmark singolo
+        bookmark_index = self.get_bookmark_at(event.pos())
+        remove_single_action = QAction("Rimuovi bookmark singolo", self)
+        if bookmark_index is not None:
+            remove_single_action.triggered.connect(lambda: self.removeBookmark(bookmark_index))
+        else:
+            remove_single_action.setEnabled(False)
+        context_menu.addAction(remove_single_action)
+
+        context_menu.exec(event.globalPos())
 
     def paintEvent(self, event):
         super().paintEvent(event)


### PR DESCRIPTION
This commit introduces three main improvements:

1.  **Temporary File Cleanup:**
    - Temporary video segments created during screen recording are now tracked.
    - These segments and the `segments.txt` file are automatically deleted when the application is closed via the `closeEvent` handler.

2.  **Bookmark Context Menu:**
    - A right-click context menu has been added to the input video player's timeline slider.
    - The menu provides options to "Reset all bookmarks" and "Remove single bookmark," enhancing bookmark management.

3.  **UI Cleanup:**
    - The "Effetti" (Effects) menu has been removed from the main menu bar to simplify the interface. The dock remains accessible through the "View" menu.