### PR TITLE
feat: Aggiungi registrazione webcam simultanea con selezione dispositivo

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -3215,7 +3215,7 @@ class VideoAudioManager(QMainWindow):
         save_video_only = self.saveVideoOnlyCheckBox.isChecked()
         save_audio_only = self.saveAudioOnlyCheckBox.isChecked()
         record_webcam = self.recordWebcamCheckBox.isChecked()
-        selected_webcam = "0" if record_webcam else None
+        selected_webcam = self.webcamComboBox.currentText() if record_webcam else None
 
         self.timecodeLabel.setStyleSheet("""
             QLabel {


### PR DESCRIPTION
Questo commit introduce la funzionalità di registrare la webcam simultaneamente con lo schermo.

- Aggiunta una checkbox "Registra webcam" e un menu a tendina per la selezione del dispositivo webcam nel pannello di registrazione.
- La classe `ScreenRecorder` è stata aggiornata per elencare i dispositivi video disponibili utilizzando `dshow` e per gestire un processo `ffmpeg` separato per il feed della webcam.
- La logica di avvio e arresto della registrazione è stata resa più robusta per gestire entrambi i processi.
- La registrazione finale della webcam viene salvata con il suffisso `_webcam`, corrispondente al nome del file della registrazione principale.
- È stato aggiunto un controllo per verificare l'esistenza del file della webcam prima di tentare di rinominarlo, per prevenire errori.
- È stato corretto un errore di formattazione nel logging.