### PR TITLE
feat: Add webcam selection and fix recording failures

### DIFF
--- a/src/recorder/ScreenRecorder.py
+++ b/src/recorder/ScreenRecorder.py
@@ -217,9 +217,9 @@ class ScreenRecorder(QThread):
         if self.record_webcam and self.is_running:
             webcam_command = [
                 self.ffmpeg_path,
-                '-f', 'vfwcap',
+                '-f', 'dshow',
                 '-r', '25',
-                '-i', '0', # Using device index 0 as suggested
+                '-i', f'video={self.webcam_device}',
                 '-c:v', 'libx264',
                 '-preset', 'ultrafast',
                 '-pix_fmt', 'yuv420p',


### PR DESCRIPTION
This commit addresses two issues related to webcam recording:

1.  **Fix Webcam Recording Failures on Windows:**
    - The ffmpeg command for webcam recording was using the outdated `-f vfwcap` driver, which caused timeouts and recording failures on modern Windows systems.
    - This has been changed to use the more robust `-f dshow` driver.
    - The command now correctly uses the device name (e.g., "Integrated Webcam") instead of a hardcoded index.

2.  **Add Webcam Selection UI:**
    - To support the `dshow` driver, a `QComboBox` has been added to the recording dock in the UI.
    - This dropdown is now populated at startup with a list of available video devices, allowing the user to select which webcam to record.
    - The recording logic has been updated to pass the selected device name to the recorder.

3.  **Fix Logging TypeError:**
    - A `TypeError` in the `showError` method's logging call has been fixed by using a proper format string (`%s`). This ensures that errors are logged correctly.