### PR TITLE
fix: Correct `AttributeError` on startup

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -1165,15 +1165,6 @@ class VideoAudioManager(QMainWindow):
 
         self.transcriptionDock.addWidget(self.transcriptionTabWidget)
 
-    def paste_to_audio_ai(self, source_text_edit):
-        """
-        Copia il testo dall'area di testo sorgente all'area di testo della tab Audio AI.
-        """
-        text_to_paste = source_text_edit.toPlainText()
-        self.audioAiTextArea.setPlainText(text_to_paste)
-        self.transcriptionTabWidget.setCurrentWidget(self.audio_ai_tab)
-        self.show_status_message("Testo incollato nella tab Audio AI.")
-
         # Impostazioni voce per l'editing audio AI
         voiceSettingsWidget = self.setupVoiceSettingsUI()
         voiceSettingsWidget.setToolTip("Impostazioni voce per l'editing audio AI")
@@ -1676,6 +1667,15 @@ class VideoAudioManager(QMainWindow):
             mode="summary"
         )
         self.start_task(thread, self.onProcessComplete, self.onProcessError, self.update_status_progress)
+
+    def paste_to_audio_ai(self, source_text_edit):
+        """
+        Copia il testo dall'area di testo sorgente all'area di testo della tab Audio AI.
+        """
+        text_to_paste = source_text_edit.toPlainText()
+        self.audioAiTextArea.setPlainText(text_to_paste)
+        self.transcriptionTabWidget.setCurrentWidget(self.audio_ai_tab)
+        self.show_status_message("Testo incollato nella tab Audio AI.")
 
     def fixTranscriptionWithAI(self):
         """


### PR DESCRIPTION
This commit fixes a bug that caused the application to crash on startup with an `AttributeError: 'VideoAudioManager' object has no attribute 'dockSettingsManager'`.

The error was introduced during a previous refactoring, where the `paste_to_audio_ai` method was incorrectly placed inside the `initUI` method. This disrupted the initialization sequence, preventing `dockSettingsManager` from being created before it was accessed.

The fix moves the `paste_to_audio_ai` method to its correct location within the `VideoAudioManager` class, ensuring the proper initialization order is restored.