### PR TITLE
fix: Pin numba and llvmlite versions for Windows compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ screeninfo
 pycountry
 SpeechRecognition
 openai-whisper
+numba==0.59.1
+llvmlite==0.41.1
 yt-dlp
 anthropic
 python-pptx


### PR DESCRIPTION
This commit resolves a `[WinError 1114]` DLL loading error by pinning the versions of `numba` and `llvmlite` in `requirements.txt`. This is a known issue on some Windows environments where the latest versions of these libraries, which are dependencies of `openai-whisper`, fail to initialize correctly.

By setting specific, compatible versions (`numba==0.59.1` and `llvmlite==0.41.1`), we ensure a stable environment and prevent the runtime error.