### PR TITLE
feat: Persist recent files on disk

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -397,6 +397,7 @@ class VideoAudioManager(QMainWindow):
         self.audioOutput.setVolume(1.0)
         self.playerOutput.setAudioOutput(self.audioOutputOutput)
         self.recentFiles = []
+        self.loadRecentFiles()
         self.recording_segments = []
 
         # Blinking recording indicator
@@ -5359,10 +5360,18 @@ class VideoAudioManager(QMainWindow):
             self.loadVideo(fileName)
 
     def updateRecentFiles(self, newFile):
-        if newFile not in self.recentFiles:
-            self.recentFiles.insert(0, newFile)
-            if len(self.recentFiles) > 5:  # Limita la lista ai 5 più recenti
-                self.recentFiles.pop()
+        if newFile in self.recentFiles:
+            self.recentFiles.remove(newFile)
+
+        self.recentFiles.insert(0, newFile)
+
+        if len(self.recentFiles) > 15:  # Limita la lista ai 15 più recenti
+            self.recentFiles = self.recentFiles[:15]
+
+        # Salva la lista aggiornata nelle impostazioni
+        settings = QSettings("Genius", "GeniusAI")
+        settings.setValue("recentFiles", self.recentFiles)
+
         self.updateRecentFilesMenu()
 
     def updateRecentFilesMenu(self):
@@ -5371,6 +5380,14 @@ class VideoAudioManager(QMainWindow):
             action = QAction(os.path.basename(file), self)
             action.triggered.connect(lambda checked, f=file: self.openRecentFile(f))
             self.recentMenu.addAction(action)
+
+    def loadRecentFiles(self):
+        """Carica la lista dei file recenti da QSettings."""
+        settings = QSettings("Genius", "GeniusAI")
+        self.recentFiles = settings.value("recentFiles", [], type=list)
+        # Rimuovi i file che non esistono più
+        self.recentFiles = [f for f in self.recentFiles if os.path.exists(f)]
+
 
     def openRecentFile(self, filePath):
         self.videoPathLineEdit = filePath


### PR DESCRIPTION
This commit implements the persistence of recently opened audio/video files.

The list of recent files is now saved to `QSettings` whenever it is updated and is reloaded when the application starts. This ensures that the user's recent files are not lost between sessions.

The changes include:
- A `loadRecentFiles` method to load the list from `QSettings` at startup.
- Modification of the `updateRecentFiles` method to save the list back to `QSettings` on every update.
- The limit for recent files has been increased to 15.
- The logic now moves a re-opened file to the top of the list.