### PR TITLE
Fix: Ensure full compatibility for Browser Agent

### DIFF
--- a/src/services/BrowserAgent.py
+++ b/src/services/BrowserAgent.py
@@ -63,10 +63,12 @@ from langchain_google_genai import ChatGoogleGenerativeAI # Import Gemini client
 class GoogleLLMWrapper:
     """
     A wrapper for the ChatGoogleGenerativeAI model to ensure it has the
-    'ainvoke' method expected by the browser-use agent.
+    'ainvoke', 'provider', and 'model' attributes expected by the browser-use agent.
     """
     def __init__(self, llm):
         self.llm = llm
+        self.provider = "google"  # Expose the provider attribute
+        self.model = llm.model      # Expose the model name attribute
 
     async def ainvoke(self, *args, **kwargs):
         """Asynchronously invoke the wrapped LLM."""


### PR DESCRIPTION
This commit provides a comprehensive fix for a series of errors that prevented the BrowserAgent from running correctly. The changes address API updates in the `browser-use` library and compatibility issues with the Google Gemini LLM.

- Updated the browser initialization to use the new `BrowserSession` and `BrowserProfile` classes from the `browser-use` library, replacing the deprecated `BrowserConfig` and `Browser` classes.
- Corrected the LLM imports to use the native wrappers from `browser_use.llm` for supported models (OpenAI, Anthropic).
- Implemented a custom `GoogleLLMWrapper` class to make the `langchain` `ChatGoogleGenerativeAI` model compatible with the `browser-use` agent. The wrapper now provides the `ainvoke` method and the `provider` and `model` attributes expected by the agent's internal services.
- Applied the wrapper to the Google Gemini LLM instance before passing it to the agent.
- Removed the erroneous call to `.close()` on the browser session, as the library handles cleanup automatically.