### PR TITLE
Fix: Ensure full compatibility for Browser Agent

### DIFF
--- a/src/services/BrowserAgent.py
+++ b/src/services/BrowserAgent.py
@@ -62,13 +62,14 @@ from langchain_google_genai import ChatGoogleGenerativeAI # Import Gemini client
 # Custom wrapper to ensure compatibility with browser-use agent
 class GoogleLLMWrapper:
     """
-    A wrapper for the ChatGoogleGenerativeAI model to ensure it has the
-    'ainvoke', 'provider', and 'model' attributes expected by the browser-use agent.
+    A wrapper for the ChatGoogleGenerativeAI model to ensure it has the 'ainvoke',
+    'provider', 'model', and 'model_name' attributes expected by the browser-use agent.
     """
     def __init__(self, llm):
         self.llm = llm
-        self.provider = "google"  # Expose the provider attribute
-        self.model = llm.model      # Expose the model name attribute
+        self.provider = "google"      # Expose the provider attribute
+        self.model = llm.model          # Expose the model attribute
+        self.model_name = llm.model     # Expose the model_name attribute
 
     async def ainvoke(self, *args, **kwargs):
         """Asynchronously invoke the wrapped LLM."""


### PR DESCRIPTION
This commit provides a comprehensive fix for a series of errors that prevented the BrowserAgent from running correctly. The changes address API updates in the `browser-use` library and compatibility issues with the Google Gemini LLM.

- Updated the browser initialization to use the new `BrowserSession` and `BrowserProfile` classes from the `browser-use` library, replacing the deprecated `BrowserConfig` and `Browser` classes.
- Corrected the LLM imports to use the native wrappers from `browser_use.llm` for supported models (OpenAI, Anthropic).
- Implemented a custom `GoogleLLMWrapper` class to make the `langchain` `ChatGoogleGenerativeAI` model compatible with the `browser-use` agent. The wrapper now provides the `ainvoke` method and the `provider`, `model`, and `model_name` attributes expected by the agent's internal services.
- Applied the wrapper to the Google Gemini LLM instance before passing it to the agent.
- Removed the erroneous call to `.close()` on the browser session, as the library handles cleanup automatically.