### PR TITLE
Fix: Correct Browser Agent initialization and session handling

### DIFF
--- a/src/services/BrowserAgent.py
+++ b/src/services/BrowserAgent.py
@@ -253,7 +253,6 @@ class BrowserAgentWorker(QObject):
                 task=self.task,
                 llm=llm,
                 browser_profile=browser_profile, # Pass profile directly
-                headless=self.config.headless, # Pass headless directly
                 use_vision=self.config.use_vision,
                 max_actions_per_step=1
             )


### PR DESCRIPTION
This commit resolves two issues related to the browser agent:

1.  A `ConnectionClosedError` caused by improper browser session management. The `BrowserAgent` was manually creating a `BrowserSession`, which conflicted with the `browser-use` library's internal session management. This was fixed by allowing the `Agent` class to manage its own lifecycle by passing the `BrowserProfile` directly to its constructor.

2.  An issue where the agent would open a browser but fail to read page content. This was caused by a configuration conflict where the `headless` parameter was passed to the `Agent` constructor redundantly, as it was already specified within the `BrowserProfile`.

These changes align the implementation with the library's intended usage, resolving both the connection errors and the functional issue with page interaction.