### PR TITLE
feat: Implement save, search/replace, and keyboard controls

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -994,13 +994,6 @@ class VideoAudioManager(QMainWindow):
         self.loadButton.clicked.connect(self.loadText)
         file_actions_layout.addWidget(self.loadButton)
 
-        self.saveButton = QPushButton('')
-        self.saveButton.setIcon(QIcon(get_resource("save.png")))
-        self.saveButton.setFixedSize(32, 32)
-        self.saveButton.setToolTip("Salva Testo")
-        self.saveButton.clicked.connect(self.saveText)
-        file_actions_layout.addWidget(self.saveButton)
-
         self.saveTranscriptionButton = QPushButton('')
         self.saveTranscriptionButton.setIcon(QIcon(get_resource("save_all.png")))
         self.saveTranscriptionButton.setFixedSize(32, 32)


### PR DESCRIPTION
This commit introduces several new features, enhancements, and bug fixes:

- **Save and Autosave:**
  - Adds individual save buttons to the "Trascrizione," "Riassunto," and "Audio AI" tabs to manually save their respective content to the associated JSON file.
  - The "Trascrizione" tab now has a single, dedicated save button as requested.
  - Implements an autosave feature that triggers every 5 minutes to prevent data loss.
  - Ensures all text area changes are saved when the application is closed.
  - Fixes a critical data loss bug where the autosave feature was saving stale data instead of the latest UI text.

- **Search and Replace:**
  - Enhances the search dialog with a "Replace" QLineEdit and "Replace" and "Replace All" buttons.
  - Implements the logic for single and batch replacements.
  - Fixes a bug in "Replace All" to correctly handle case-insensitive searches.
  - Provides user feedback via a message box detailing the number of replacements made.
  - Highlights the search input field in orange when no results are found.

- **Keyboard Controls:**
  - Adds support for keyboard arrow keys to control video playback.
  - The left and right arrow keys rewind and fast-forward the **input** video player by 5 seconds.
  - These controls are disabled when a text input field is in focus to prevent conflicts.

- **Code Cleanup:**
  - Removed dead code related to output player controls that were no longer used.