### PR TITLE
This commit introduces a new feature that allows users to take time-c…

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -5576,8 +5576,8 @@ class VideoAudioManager(QMainWindow):
             super().keyPressEvent(event)
 
     def eventFilter(self, source, event):
-        if source is self.videoOverlay and event.type() == QEvent.Type.MouseButtonPress:
-            if event.button() == Qt.MouseButton.RightButton:
+        if source is self.videoOverlay and event.type() == QEvent.Type.MouseButtonDblClick:
+            if event.button() == Qt.MouseButton.LeftButton:
                 self.add_video_note()
                 return True
         return super().eventFilter(source, event)


### PR DESCRIPTION
…oded notes on videos and enhances the input dialog to support multi-line text.

A new "Note Video" dock has been added to the UI. Users can double-click on the video to add a note at the current timecode. These notes are displayed in the new dock. A right-click on the video now correctly resets the frame's zoom and pan.

The feature includes the following functionalities:
- A custom multi-line input dialog for adding and editing notes.
- Double-clicking a note in the list seeks the video to the corresponding timecode.
- Notes can be edited and deleted using buttons within the dock.
- All notes are persisted in the video's associated JSON file, ensuring they are saved and loaded across sessions.