### PR TITLE
Refactor: Improve timestamp precision and visibility

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -1965,17 +1965,24 @@ class VideoAudioManager(QMainWindow):
             logging.error(f"Errore durante il salvataggio del file JSON aggiornato: {e}")
 
     def handleTimecodeToggle(self, checked):
-        self.audioAiTextArea.setReadOnly(checked)
+        # Applica la logica a entrambe le aree di testo
+        text_areas = [self.transcriptionTextArea, self.audioAiTextArea]
         self.timecodeEnabled = checked
 
-        if checked:
-            # Salva l'HTML originale e applica i timecode
-            self.original_audio_ai_html = self.audioAiTextArea.toHtml()
-            updated_html = self.calculateAndDisplayTimeCodeAtEndOfSentences(self.original_audio_ai_html)
-            self.audioAiTextArea.setHtml(updated_html)
-        else:
-            # Ripristina l'HTML originale
-            self.audioAiTextArea.setHtml(self.original_audio_ai_html)
+        for text_area in text_areas:
+            text_area.setReadOnly(checked)
+            if checked:
+                # Salva l'HTML corrente e applica i timecode
+                original_html = text_area.toHtml()
+                # Salva l'originale in un attributo dinamico per evitare conflitti
+                setattr(self, f"original_html_for_{text_area.objectName()}", original_html)
+                updated_html = self.calculateAndDisplayTimeCodeAtEndOfSentences(original_html)
+                text_area.setHtml(updated_html)
+            else:
+                # Ripristina l'HTML originale
+                original_html = getattr(self, f"original_html_for_{text_area.objectName()}", "")
+                if original_html:
+                    text_area.setHtml(original_html)
 
 
     def updateProgressDialog(self, value, label):


### PR DESCRIPTION
This commit enhances the timestamp functionality in the transcription area by:

-   **Adding Tenths of a Second:** Timestamps are now displayed with tenths of a second (e.g., `[MM:SS.d]`) for greater precision.
-   **Changing Timestamp Color:** The timestamp color has been changed to cyan to make it more distinguishable from the transcription text.
-   **Updating Parsing Logic:** The regular expressions and parsing logic have been updated to handle the new timestamp format, ensuring that features like video synchronization continue to work correctly.
-   **Updating Signal Type:** The `timestampDoubleClicked` signal in `CustumTextEdit` has been updated from `int` to `float` to accommodate the new precision.
-   **Fix:** The `handleTimecodeToggle` function has been updated to apply the new formatting to both the transcription and the AI audio text areas, not just the latter.