### PR TITLE
Fix: Correctly save and restore dock layout state

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -3166,13 +3166,10 @@ class VideoAudioManager(QMainWindow):
 
     def applyDockSettings(self):
         """
-        Applies the loaded dock settings. If applying fails or no settings
-        were loaded, it applies a default layout.
+        Applies the loaded dock settings. The settings manager will handle
+        falling back to a default layout if necessary.
         """
-        if not self.dockSettingsManager.apply_settings():
-            # Fallback to default if settings could not be restored
-            self.set_default_dock_layout()
-            self.updateViewMenu()
+        self.dockSettingsManager.apply_settings()
 
     def closeEvent(self, event):
         # Salva tutte le modifiche correnti prima di chiudere


### PR DESCRIPTION
This commit provides a robust and correct implementation for saving and restoring the application's dock layout, including the state of floating docks.

The key changes are:
- The `DockSettingsManager` now uses `pyqtgraph.dockarea.DockArea`'s `saveState()` and `restoreState()` methods, which is the correct and idiomatic way to handle layout persistence with this library.
- The restoration of the dock layout is now deferred until after the main window is fully visible (`window.show()`). This is achieved by splitting the process into `load_settings` (to read from the file) and `apply_settings` (to restore the state).
- The `applyDockSettings` method in the main window class has been simplified to correctly call the manager's `apply_settings` method.
- The `saveDockLayout` method, connected to the "Save Layout" menu action, correctly calls `save_settings`, ensuring both manual saves and saves on exit work as expected.

This approach resolves the previous issues where floating docks were not saved correctly and a subsequent regression where the layout was not restored at all due to incorrect timing of the restore operation.