### PR TITLE
Fix: Pass parent window to PptxGeneration service

### DIFF
--- a/src/ui/PptxDialog.py
+++ b/src/ui/PptxDialog.py
@@ -147,7 +147,7 @@ class PptxDialog(QDialog):
 
         settings = self.get_settings()
         image_paths = PptxGeneration.generate_preview(
-            self,
+            self.parent(),
             ai_text,
             settings["template_path"]
         )
@@ -172,7 +172,7 @@ class PptxDialog(QDialog):
 
         settings = self.get_settings()
         PptxGeneration.createPresentationFromText(
-            self,
+            self.parent(),
             ai_text,
             save_path,
             settings["template_path"]


### PR DESCRIPTION
The `PptxGeneration` service requires access to application-level methods like `get_temp_dir()`, which are located on the main window. The `PptxDialog` was incorrectly passing itself (`self`) as the parent object.

This commit corrects the calls in `PptxDialog` to `generate_preview` and `createPresentationFromText` to pass `self.parent()` instead. This provides the service with the correct context, resolving the `AttributeError` and preventing similar issues.