### PR TITLE
Refactor: Improve PowerPoint preview generation and UI

### DIFF
--- a/src/services/PptxGeneration.py
+++ b/src/services/PptxGeneration.py
@@ -420,7 +420,7 @@ class PptxGeneration:
                 QMessageBox.critical(parent, "Errore Creazione PPTX", f"Si è verificato un errore: {e}")
 
     @staticmethod
-    def generate_preview(parent, testo, template_path=None):
+    def generate_preview(parent, testo, template_path=None, num_slides=None):
         """Genera un'anteprima della presentazione come immagini."""
         if sys.platform != "win32":
             QMessageBox.warning(parent, "Funzionalità non supportata", "La generazione dell'anteprima è supportata solo su Windows.")
@@ -440,7 +440,8 @@ class PptxGeneration:
             # 1. Crea un file .pptx temporaneo
             temp_pptx_file = parent.get_temp_filepath(suffix=".pptx")
 
-            PptxGeneration.createPresentationFromText(parent, testo, temp_pptx_file, template_path)
+            # Passa num_slides per coerenza con la generazione finale
+            PptxGeneration.createPresentationFromText(parent, testo, temp_pptx_file, template_path, num_slides=num_slides)
 
             # 2. Usa COM per esportare le slide come immagini
             powerpoint = win32com.client.Dispatch("PowerPoint.Application")

--- a/src/ui/PptxDialog.py
+++ b/src/ui/PptxDialog.py
@@ -149,14 +149,14 @@ class PptxDialog(QDialog):
         image_paths = PptxGeneration.generate_preview(
             self.parent(),
             ai_text,
-            settings["template_path"]
+            settings["template_path"],
+            settings["num_slides"]
         )
 
         if image_paths:
             preview_dialog = PreviewDialog(image_paths, self)
-            if preview_dialog.exec():
-                self.handle_generate()
-            preview_dialog.cleanup()
+            preview_dialog.exec()  # Mostra la dialog in modo modale
+            preview_dialog.cleanup() # Pulisce le immagini temporanee dopo la chiusura
 
     def handle_generate(self):
         """Gestisce la generazione della presentazione finale."""
@@ -175,7 +175,8 @@ class PptxDialog(QDialog):
             self.parent(),
             ai_text,
             save_path,
-            settings["template_path"]
+            settings["template_path"],
+            num_slides=settings["num_slides"]
         )
         self.accept()
 

--- a/src/ui/PreviewDialog.py
+++ b/src/ui/PreviewDialog.py
@@ -39,9 +39,8 @@ class PreviewDialog(QDialog):
         main_layout.addWidget(scroll_area)
 
         # Pulsanti
-        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Save | QDialogButtonBox.StandardButton.Cancel)
-        self.button_box.accepted.connect(self.accept)
-        self.button_box.rejected.connect(self.reject)
+        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+        self.button_box.accepted.connect(self.accept) # Chiude semplicemente la dialog
 
         main_layout.addWidget(self.button_box)
 


### PR DESCRIPTION
This commit resolves multiple issues related to the PowerPoint preview feature.

1.  **Fix `AttributeError`**: The `PptxGeneration` service was receiving the `PptxDialog` instance instead of the main window, causing an `AttributeError` when trying to access `get_temp_dir()`. This is fixed by passing `self.parent()` from the dialog.

2.  **Ensure Preview Consistency**: The preview generation logic now accepts the `num_slides` parameter, ensuring that the generated preview correctly reflects the selected template and slide count, which fixes a bug where the first slide was missing.

3.  **Improve Preview UX**: The `PreviewDialog` is now a view-only component with a single "OK" button. The workflow in `PptxDialog` has been updated to show the preview directly without requiring a confirmation step to generate the final file, simplifying the user experience.