### PR TITLE
Feat: Auto-populate recording path on project load

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -6067,6 +6067,7 @@ class VideoAudioManager(QMainWindow):
             return
 
         self.current_project_path = os.path.dirname(gnai_path)
+        self.folderPathLineEdit.setText(self.current_project_path)
         self.projectDock.load_project_data(project_data, self.current_project_path, gnai_path)
         self.show_status_message(f"Progetto '{project_data.get('projectName')}' caricato.")
         if not self.projectDock.isVisible():


### PR DESCRIPTION
When a project is opened, the file path input field in the recording dock is now automatically populated with the path of the project's directory.

This is achieved by updating the `folderPathLineEdit` widget with the `current_project_path` in the `load_project` method of the `VideoAudioManager` class. This streamlines the process of saving new recordings, ensuring they are placed in the active project's directory by default.