### PR TITLE
refactor: Enhance project management and fix UI signals

### DIFF
--- a/src/ui/ProjectDock.py
+++ b/src/ui/ProjectDock.py
@@ -34,6 +34,7 @@ class ProjectDock(CustomDock):
 
         self._setup_ui()
         self.tree_clips.itemDoubleClicked.connect(self._on_clip_selected)
+        self.btn_merge_clips.clicked.connect(self.merge_clips_requested.emit)
         self.tree_clips.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.tree_clips.customContextMenuRequested.connect(self.show_context_menu)
 
@@ -99,7 +100,7 @@ class ProjectDock(CustomDock):
         self.btn_refresh_clips = QPushButton()
         self.btn_refresh_clips.setIcon(QIcon(get_resource("sync.png")))
         self.btn_refresh_clips.setToolTip("Aggiorna la lista delle clip")
-        self.btn_refresh_clips.clicked.connect(self.reload_project_requested.emit)
+        self.btn_refresh_clips.clicked.connect(self.project_clips_folder_changed.emit)
         self.btn_refresh_clips.setFixedSize(32, 32)
         buttons_layout.addWidget(self.btn_refresh_clips)
 


### PR DESCRIPTION
This commit introduces a suite of features to significantly improve project management and automates file handling, alongside a critical bug fix for UI signal handling.

- **Reliable Automatic Clip Ingestion**: When a video file is added to a project's 'clips' directory, the application now reliably detects it using a debounced file watcher. It extracts the clip's metadata, updates the `.gnai` project file, and refreshes the UI to show the new clip automatically.

- **Save Processed Video to Project**: Processed videos from the output player are saved directly into the active project's 'clips' folder with an `_output` suffix.

- **Save Project Menu Item**: A "Save Project" item has been added to the "File" menu, allowing users to manually save the current state of their `.gnai` file.

- **Custom Project Location**: Users can now select a custom destination folder when creating a new project via a `QFileDialog`.

- **Project Dock UI/UX**:
  - A manual refresh button has been added to the clips view.
  - A context menu option allows for the deletion of clips from the project and the filesystem.
  - A button is now available to open the project's root directory in the system's file explorer.

- **Bug Fix**: Corrected an `AttributeError` in `ProjectDock.py` caused by a mismatched signal name for the refresh button. Restored the inadvertently removed signal connection for the 'Merge Clips' button.