### PR TITLE
fix: Clear workspace when creating a new project

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -6047,7 +6047,48 @@ class VideoAudioManager(QMainWindow):
 
     # --- PROJECT MANAGEMENT METHODS ---
 
+    def _clear_workspace(self):
+        """
+        Pulisce completamente lo stato dell'applicazione per prepararsi a un nuovo progetto.
+        """
+        # 1. Pulisci i video player e i percorsi associati
+        self.releaseSourceVideo()
+        self.releaseOutputVideo()
+
+        # 2. Pulisci le aree di testo
+        self.transcriptionTextArea.clear()
+        self.audioAiTextArea.clear()
+        self.summaryTextArea.clear()
+
+        # 3. Resetta lo stato interno delle trascrizioni e dei riassunti
+        self.transcription_original = ""
+        self.transcription_corrected = ""
+        self.summaries = {}
+        self.active_summary_type = None
+        self.summary_text = ""
+        self.summary_generated = ""
+        self.summary_generated_integrated = ""
+        self.original_audio_ai_html = ""
+        self.transcriptionViewToggle.setChecked(False)
+        self.transcriptionViewToggle.setEnabled(False)
+        self.integrazioneToggle.setChecked(False)
+        self.integrazioneToggle.setEnabled(False)
+
+        # 4. Resetta i percorsi e lo stato del progetto
+        self.current_project_path = None
+        self.current_video_path = None
+        self.current_audio_path = None
+
+        # 5. Pulisci i dock informativi
+        self.infoDock.clear_info()
+        self.projectDock.clear_project()
+
+        self.show_status_message("Workspace pulito. Pronto per un nuovo progetto.")
+
     def create_new_project(self):
+        # Pulisci l'area di lavoro prima di creare un nuovo progetto
+        self._clear_workspace()
+
         project_name, ok = QInputDialog.getText(self, "Nuovo Progetto", "Inserisci il nome del nuovo progetto:")
         if not ok or not project_name.strip():
             # L'utente ha annullato o non ha inserito un nome

--- a/src/ui/ProjectDock.py
+++ b/src/ui/ProjectDock.py
@@ -174,7 +174,8 @@ class ProjectDock(CustomDock):
             item.setText(0, "Nessuna clip trovata.")
             item.setDisabled(True)
 
-    def clear_dock(self):
+    def clear_project(self):
+        """Resetta il dock allo stato iniziale, pulendo i dati del progetto."""
         if self.file_watcher.directories():
             self.file_watcher.removePaths(self.file_watcher.directories())
         self.lbl_project_name.setText("N/A")
@@ -183,3 +184,8 @@ class ProjectDock(CustomDock):
         self.project_data = None
         self.project_dir = None
         self.gnai_path = None
+
+        # Aggiungi un item placeholder per chiarezza
+        item = QTreeWidgetItem(self.tree_clips)
+        item.setText(0, "Nessun progetto caricato.")
+        item.setDisabled(True)


### PR DESCRIPTION
When creating a new project while another was already open, the application state (e.g., loaded videos, transcription text) was not reset. This caused data from the old project to persist in the new one.

This change introduces a `_clear_workspace` method in `VideoAudioManager` that resets all relevant UI components and internal state variables. This method is now called at the beginning of `create_new_project` to ensure a clean state.

Additionally, the `clear_dock` method in `ProjectDock` was renamed to `clear_project` for better clarity.