### PR TITLE
feat: Save downloads to project folder

### DIFF
--- a/src/ui/DownloadDialog.py
+++ b/src/ui/DownloadDialog.py
@@ -75,7 +75,13 @@ class DownloadDialog(QDialog):
         self.parent_window.video_download_language = video_language
         logging.debug(video_language)
 
-        downloads_dir = os.path.join(os.getcwd(), "downloads")
+        # Se un progetto è attivo, salva nella cartella 'downloads' del progetto,
+        # altrimenti nella cartella 'downloads' principale.
+        if self.parent_window.current_project_path:
+            downloads_dir = os.path.join(self.parent_window.current_project_path, "downloads")
+        else:
+            downloads_dir = os.path.join(os.getcwd(), "downloads")
+
         os.makedirs(downloads_dir, exist_ok=True)
 
         try:


### PR DESCRIPTION
Modify the video download logic to save files into a 'downloads' subfolder within the currently active project's directory.

If no project is open, the download path falls back to the original behavior, saving files to a root-level 'downloads' folder.

This is achieved by checking for `self.parent_window.current_project_path` in `src/ui/DownloadDialog.py` and constructing the path accordingly.