### PR TITLE
feat: Add audio-only placeholder and project downloads folder clips

### DIFF
--- a/src/ui/ProjectDock.py
+++ b/src/ui/ProjectDock.py
@@ -190,11 +190,11 @@ class ProjectDock(CustomDock):
                 full_path = os.path.join(clips_dir, clip.get("clip_filename", ""))
                 item.setData(0, Qt.ItemDataRole.UserRole, full_path)
 
-        # Carica file dalla cartella 'download' del progetto
-        download_folder_path = os.path.join(project_dir, "download")
+        # Carica file dalla cartella 'downloads' del progetto
+        download_folder_path = os.path.join(project_dir, "downloads")
         if os.path.exists(download_folder_path):
             download_root = QTreeWidgetItem(self.tree_clips)
-            download_root.setText(0, "Download")
+            download_root.setText(0, "Downloads")
             download_root.setExpanded(True)
 
             media_extensions = {".mp4", ".mov", ".avi", ".mkv", ".mp3", ".wav", ".aac"}


### PR DESCRIPTION
This commit introduces two new features:

1.  When an audio-only file is loaded, the video player now displays a static image with the text "Solo audio" instead of a blank video widget.

2.  The project dock's "Clip Video" section now lists media files from the project's local `downloads` folder, in addition to the clips already included in the project's `clips` folder. This makes it easier to access and import new files related to the project.