### PR TITLE
feat: Implement spacebar play/pause for video players

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -742,6 +742,7 @@ class VideoAudioManager(QMainWindow):
         self.videoCropWidget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.videoCropWidget.setToolTip("Area di visualizzazione e ritaglio video input")
         self.player.setVideoOutput(self.videoCropWidget)
+        self.videoCropWidget.spacePressed.connect(self.togglePlayPause)
 
         # Aggiungi un QLabel per l'immagine "Solo audio"
         self.audioOnlyLabel = QLabel(self.videoContainer)
@@ -860,6 +861,7 @@ class VideoAudioManager(QMainWindow):
         self.videoOutputWidget.setAcceptDrops(True)
         self.videoOutputWidget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.videoOutputWidget.setToolTip("Area di visualizzazione e ritaglio video output")
+        self.videoOutputWidget.spacePressed.connect(self.togglePlayPauseOutput)
 
         self.playerOutput.setAudioOutput(self.audioOutputOutput)
         self.playerOutput.setVideoOutput(self.videoOutputWidget)

--- a/src/ui/CustVideoWidget.py
+++ b/src/ui/CustVideoWidget.py
@@ -8,6 +8,8 @@ import logging
 
 class CropVideoWidget(QVideoWidget):
     """A simple video widget that serves as a display surface for video content."""
+    spacePressed = pyqtSignal()
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setMinimumWidth(400)
@@ -19,6 +21,8 @@ class CropVideoWidget(QVideoWidget):
                 self.setFullScreen(False)
             else:
                 self.setFullScreen(True)
+        elif event.key() == Qt.Key.Key_Space:
+            self.spacePressed.emit()
         super().keyPressEvent(event)
 
 


### PR DESCRIPTION
Adds a `spacePressed` signal to the `CropVideoWidget`. This signal is emitted when the spacebar is pressed while the widget has focus.

In the main `TGeniusAI` window, this new signal is connected to the existing `togglePlayPause` and `togglePlayPauseOutput` methods for the input and output video players, respectively. This allows users to play and pause the video using the spacebar when the corresponding video player is in focus.