### PR TITLE
fix: Prevent crash on invalid model selection

### DIFF
--- a/src/services/MeetingSummarizer.py
+++ b/src/services/MeetingSummarizer.py
@@ -78,6 +78,10 @@ class MeetingSummarizer(QThread):
         Metodo interno che seleziona l'API corretta e genera il riassunto.
         Restituisce una tupla (testo_riassunto, input_tokens, output_tokens) o una stringa di errore.
         """
+        # 0. Verifica preliminare del modello selezionato
+        if self.selected_model.startswith('---'):
+            return "Errore: Seleziona un modello AI valido dal menu."
+
         # 1. Verifica percorso prompt
         if not PROMPT_MEETING_SUMMARY or not os.path.exists(PROMPT_MEETING_SUMMARY):
              error_msg = f"File prompt non trovato per riassunto meeting: {PROMPT_MEETING_SUMMARY}"


### PR DESCRIPTION
The meeting summarizer was crashing when a UI separator (e.g., '--- Anthropic ---') was selected as a model.

This change adds a check to validate the model name before processing, preventing the error and providing a user-friendly message.