### PR TITLE
feat: Add optional frame interpolation with Optical Flow

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -4585,29 +4585,7 @@ class VideoAudioManager(QMainWindow):
                 is_project_save = True
 
         video_saver = VideoSaver(self)
-        thread = None
-
-        if save_options.get('use_slow_motion', False):
-            thread = video_saver.save_with_slow_motion(
-                self.videoPathLineOutputEdit,
-                fileName,
-                factor=save_options['slow_motion_factor']
-            )
-        else:
-            rate = 1.0
-            if save_options['save_with_speed']:
-                rate = self.speedSpinBoxOutput.value()
-                if rate == 0: rate = 1.0
-
-            if save_options['use_compression']:
-                thread = video_saver.save_compressed(
-                    self.videoPathLineOutputEdit, fileName,
-                    quality=save_options['compression_quality'], playback_rate=rate
-                )
-            else:
-                thread = video_saver.save_original(
-                    self.videoPathLineOutputEdit, fileName, playback_rate=rate
-                )
+        thread = video_saver.save_video(self.videoPathLineOutputEdit, fileName, save_options)
 
         if thread:
             self.start_task(thread, lambda path: self.onSaveCompleted(path, is_project_save=is_project_save), self.onSaveError, self.update_status_progress)

--- a/src/services/VideoSaver.py
+++ b/src/services/VideoSaver.py
@@ -3,204 +3,226 @@ import subprocess
 import re
 import json
 import shutil
-from PyQt6.QtCore import QThread, pyqtSignal
+import tempfile
 import cv2
 import numpy as np
-from moviepy.editor import VideoFileClip, AudioFileClip
+from PyQt6.QtCore import QThread, pyqtSignal
+from moviepy.editor import VideoFileClip
 
-
-class OpticalFlowThread(QThread):
+class VideoProcessingThread(QThread):
     progress = pyqtSignal(int, str)
     completed = pyqtSignal(str)
     error = pyqtSignal(str)
 
-    def __init__(self, source_path, target_path, factor, parent=None):
+    def __init__(self, source_path, target_path, options, parent=None):
         super().__init__(parent)
         self.source_path = source_path
         self.target_path = target_path
-        self.factor = int(factor)
+        self.options = options
+        self.process = None
         self.running = True
-
-    def run(self):
-        temp_video_path = None
-        try:
-            self.progress.emit(0, "Inizializzazione slow motion con Optical Flow...")
-
-            # 1. Video processing with OpenCV
-            cap = cv2.VideoCapture(self.source_path)
-            if not cap.isOpened():
-                raise IOError("Impossibile aprire il file video.")
-
-            width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-            height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-            fps = cap.get(cv2.CAP_PROP_FPS)
-            total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-
-            temp_video_path = os.path.splitext(self.target_path)[0] + "_temp_slow.mp4"
-            fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-            out = cv2.VideoWriter(temp_video_path, fourcc, fps * self.factor, (width, height))
-
-            ret, prev_frame = cap.read()
-            if not ret:
-                raise ValueError("Impossibile leggere il primo frame.")
-
-            prev_gray = cv2.cvtColor(prev_frame, cv2.COLOR_BGR2GRAY)
-            frame_count = 1
-
-            while self.running:
-                ret, frame = cap.read()
-                if not ret:
-                    break
-
-                progress_percent = int((frame_count / total_frames) * 80)
-                self.progress.emit(progress_percent, f"Generazione frames: {frame_count}/{total_frames}")
-
-                gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-                flow = cv2.calcOpticalFlowFarneback(prev_gray, gray, None, 0.5, 3, 15, 3, 5, 1.2, 0)
-
-                out.write(prev_frame)
-
-                h, w = flow.shape[:2]
-                x, y = np.meshgrid(np.arange(w), np.arange(h))
-                for i in range(1, self.factor):
-                    if not self.running: break
-                    alpha = i / self.factor
-                    map_x = (x - (1 - alpha) * flow[..., 0]).astype(np.float32)
-                    map_y = (y - (1 - alpha) * flow[..., 1]).astype(np.float32)
-                    interp_frame = cv2.remap(frame, map_x, map_y, cv2.INTER_LINEAR)
-                    out.write(interp_frame)
-
-                if not self.running: break
-
-                prev_frame = frame
-                prev_gray = gray
-                frame_count += 1
-
-            if self.running:
-                out.write(prev_frame) # Scrive l'ultimo frame
-
-            cap.release()
-            out.release()
-
-            if not self.running:
-                self.error.emit("Operazione annullata.")
-                return
-
-            # 2. Audio processing with moviepy
-            self.progress.emit(85, "Processo audio...")
-            video_clip = VideoFileClip(temp_video_path)
-
-            try:
-                original_audio = VideoFileClip(self.source_path).audio
-                if original_audio:
-                    stretched_audio = original_audio.set_duration(video_clip.duration)
-                    final_clip = video_clip.set_audio(stretched_audio)
-                else:
-                    final_clip = video_clip
-            except Exception as e:
-                final_clip = video_clip
-
-
-            # 3. Write final video
-            self.progress.emit(90, "Salvataggio finale...")
-            final_clip.write_videofile(self.target_path, codec='libx264', audio_codec='aac')
-
-            self.progress.emit(100, "Completato")
-            self.completed.emit(self.target_path)
-
-        except Exception as e:
-            if self.running:
-                self.error.emit(str(e))
-        finally:
-            # Cleanup
-            if 'cap' in locals() and cap.isOpened(): cap.release()
-            if 'out' in locals() and out.isOpened(): out.release()
-            if 'video_clip' in locals(): video_clip.close()
-            if 'original_audio' in locals() and original_audio: original_audio.close()
-            if 'final_clip' in locals(): final_clip.close()
-            if temp_video_path and os.path.exists(temp_video_path):
-                os.remove(temp_video_path)
+        self.temp_interpolated_video = None
 
     def stop(self):
         self.running = False
-
-
-class FfmpegThread(QThread):
-    """
-    Un thread per eseguire comandi FFmpeg in background,
-    emettendo segnali per il progresso, il completamento o l'errore.
-    """
-    progress = pyqtSignal(int, str)
-    completed = pyqtSignal(str)
-    error = pyqtSignal(str)
-
-    def __init__(self, command, source_path, parent=None):
-        super().__init__(parent)
-        self.command = command
-        self.source_path = source_path
-        self.process = None
-
-    def run(self):
-        try:
-            self.process = subprocess.Popen(
-                self.command,
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                universal_newlines=True,
-                creationflags=subprocess.CREATE_NO_WINDOW
-            )
-
-            video_info = self._get_video_info(self.source_path)
-            duration = float(video_info.get('duration', 0))
-
-            while True:
-                if self.process is None or self.process.poll() is not None:
-                    break
-
-                line = self.process.stderr.readline()
-                if 'time=' in line:
-                    try:
-                        time_pattern = r'time=(\d+:\d+:\d+\.\d+)'
-                        match = re.search(time_pattern, line)
-                        if match:
-                            current_time_str = match.group(1)
-                            h, m, s_ms = current_time_str.split(':')
-                            s = float(s_ms)
-                            seconds = float(h) * 3600 + float(m) * 60 + s
-                            if duration > 0:
-                                percent = min(int((seconds / duration) * 100), 99)
-                                self.progress.emit(percent, f"Elaborazione: {percent}%")
-                    except Exception:
-                        pass
-
-            if self.process and self.process.returncode != 0:
-                error_output = self.process.stderr.read()
-                self.error.emit(f"Errore FFmpeg: {error_output}")
-            elif self.process:
-                self.completed.emit(self.command[-1])
-
-        except Exception as e:
-            self.error.emit(str(e))
-
-    def stop(self):
         if self.process:
             self.process.kill()
             self.process = None
+        self.progress.emit(0, "Operazione annullata.")
 
-    def _get_video_info(self, video_path):
+    def run(self):
         try:
-            ffprobe_path = 'ffmpeg/bin/ffprobe.exe'
-            command = [
-                ffprobe_path, '-v', 'error', '-show_entries', 'format=duration',
-                '-of', 'json', video_path
-            ]
-            result = subprocess.run(command, capture_output=True, text=True, creationflags=subprocess.CREATE_NO_WINDOW)
-            if result.returncode == 0:
-                output = json.loads(result.stdout)
-                return {'duration': float(output.get('format', {}).get('duration', 0))}
-            return {'duration': 0}
+            video_input_path = self.source_path
+
+            # Stage 1: Frame Interpolation (Optional)
+            if self.options.get('use_interpolation'):
+                self.temp_interpolated_video = self._run_interpolation_stage()
+                if not self.running: return
+                video_input_path = self.temp_interpolated_video
+
+            # Stage 2: FFmpeg Processing
+            self._run_ffmpeg_stage(video_input_path)
+
+        except Exception as e:
+            if self.running:
+                self.error.emit(f"Errore: {e}")
+        finally:
+            # Cleanup temporary files
+            if self.temp_interpolated_video and os.path.exists(self.temp_interpolated_video):
+                os.remove(self.temp_interpolated_video)
+
+    def _run_interpolation_stage(self):
+        self.progress.emit(0, "Fase 1: Interpolazione frame con Optical Flow...")
+
+        cap = cv2.VideoCapture(self.source_path)
+        if not cap.isOpened():
+            raise IOError("Impossibile aprire il file video sorgente.")
+
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        factor = self.options['interpolation_factor']
+
+        temp_video_path = os.path.join(tempfile.gettempdir(), f"temp_interpolated_{os.path.basename(self.target_path)}")
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+        out = cv2.VideoWriter(temp_video_path, fourcc, fps * factor, (width, height))
+
+        ret, prev_frame = cap.read()
+        if not ret:
+            raise ValueError("Impossibile leggere il primo frame del video.")
+
+        prev_gray = cv2.cvtColor(prev_frame, cv2.COLOR_BGR2GRAY)
+        frame_count = 0
+
+        while self.running:
+            ret, frame = cap.read()
+            if not ret:
+                break
+
+            progress_percent = int((frame_count / total_frames) * 50) # Interpolation is 50% of the work
+            self.progress.emit(progress_percent, f"Interpolazione: Frame {frame_count}/{total_frames}")
+
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            flow = cv2.calcOpticalFlowFarneback(prev_gray, gray, None, 0.5, 3, 15, 3, 5, 1.2, 0)
+
+            out.write(prev_frame)
+
+            h, w = flow.shape[:2]
+            x, y = np.meshgrid(np.arange(w), np.arange(h))
+            for i in range(1, factor):
+                if not self.running: break
+                alpha = i / factor
+                map_x = (x + alpha * flow[..., 0]).astype(np.float32)
+                map_y = (y + alpha * flow[..., 1]).astype(np.float32)
+                interp_frame = cv2.remap(prev_frame, map_x, map_y, cv2.INTER_LINEAR)
+                out.write(interp_frame)
+
+            if not self.running: break
+
+            prev_frame = frame
+            prev_gray = gray
+            frame_count += 1
+
+        if self.running:
+            out.write(prev_frame)
+
+        cap.release()
+        out.release()
+
+        if not self.running:
+            raise InterruptedError("Processo di interpolazione annullato.")
+
+        return temp_video_path
+
+    def _run_ffmpeg_stage(self, video_input_path):
+        self.progress.emit(50, "Fase 2: Processo FFmpeg...")
+
+        ffmpeg_path = 'ffmpeg/bin/ffmpeg.exe'
+        command = [ffmpeg_path, '-y', '-i', video_input_path]
+
+        # Audio input must always be the original source
+        command.extend(['-i', self.source_path])
+
+        video_filters = []
+        audio_filters = []
+
+        # Speed change
+        if self.options.get('save_with_speed', False):
+            # The parent window must have a speedSpinBoxOutput attribute
+            playback_rate = self.parent().speedSpinBoxOutput.value() if self.parent() else 1.0
+            if playback_rate == 0: playback_rate = 1.0
+
+            if playback_rate != 1.0 and playback_rate > 0:
+                video_filters.append(f"setpts={1.0/playback_rate}*PTS")
+
+                # Build atempo filter chain for audio
+                atempo_filters = []
+                rate = playback_rate
+                while rate > 2.0:
+                    atempo_filters.append("atempo=2.0")
+                    rate /= 2.0
+                if rate != 1.0:
+                    atempo_filters.append(f"atempo={rate}")
+                if atempo_filters:
+                    audio_filters.append(','.join(atempo_filters))
+
+        if video_filters:
+            command.extend(['-filter:v', ",".join(video_filters)])
+        if audio_filters:
+            command.extend(['-filter:a', ",".join(audio_filters)])
+
+        # Compression
+        if self.options.get('use_compression', False):
+            quality = self.options.get('compression_quality', 5)
+            crf = 28 - quality
+            command.extend(['-c:v', 'libx264', '-preset', 'medium', '-crf', str(crf)])
+            command.extend(['-c:a', 'aac', '-b:a', '128k'])
+        else:
+            command.extend(['-c:v', 'libx264', '-preset', 'medium', '-crf', '18'])
+            command.extend(['-c:a', 'aac', '-b:a', '192k'])
+
+        # Map streams: video from the (potentially interpolated) input, audio from the original source
+        command.extend(['-map', '0:v:0', '-map', '1:a:0?'])
+        command.extend([self.target_path])
+
+        self.process = subprocess.Popen(
+            command,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+            creationflags=subprocess.CREATE_NO_WINDOW
+        )
+
+        duration = self._get_video_duration(self.source_path)
+
+        while self.running:
+            if self.process is None or self.process.poll() is not None:
+                break
+
+            line = self.process.stderr.readline()
+            if 'time=' in line:
+                match = re.search(r'time=(\d+:\d+:\d+\.\d+)', line)
+                if match:
+                    current_time_str = match.group(1)
+                    h, m, s_ms = current_time_str.split(':')
+                    seconds = float(h) * 3600 + float(m) * 60 + float(s_ms)
+                    if duration > 0:
+                        percent = 50 + min(int((seconds / duration) * 50), 49)
+                        self.progress.emit(percent, f"Finalizzazione: {percent}%")
+
+        if not self.running:
+             raise InterruptedError("Processo FFmpeg annullato.")
+
+        if self.process.returncode != 0:
+            error_output = self.process.stderr.read()
+            raise RuntimeError(f"Errore FFmpeg: {error_output}")
+
+        self.progress.emit(100, "Completato")
+        self.completed.emit(self.target_path)
+
+    def _get_video_duration(self, video_path):
+        try:
+            clip = VideoFileClip(video_path)
+            duration = clip.duration
+            clip.close()
+            return duration
         except Exception:
-            return {'duration': 0}
+            return 0
+
+
+class VideoSaver:
+    def __init__(self, parent=None):
+        self.parent = parent
+
+    def save_video(self, source_path, target_path, options):
+        # If no special options are selected, just copy the file
+        if not options.get('use_interpolation') and not options.get('save_with_speed') and not options.get('use_compression'):
+             # We use a simple copy thread for consistency
+            return CopyThread(source_path, target_path, self.parent)
+
+        return VideoProcessingThread(source_path, target_path, options, self.parent)
+
 
 class CopyThread(QThread):
     """Un semplice thread per copiare un file, per coerenza con l'API asincrona."""
@@ -224,57 +246,3 @@ class CopyThread(QThread):
 
     def stop(self):
         pass
-
-class VideoSaver:
-    """
-    Classe per gestire il salvataggio dei video. Restituisce un QThread
-    per l'esecuzione asincrona.
-    """
-    def __init__(self, parent=None):
-        self.parent = parent
-
-    def save_with_slow_motion(self, source_path, target_path, factor):
-        return OpticalFlowThread(source_path, target_path, factor, self.parent)
-
-    def save_original(self, source_path, target_path, playback_rate=1.0):
-        if playback_rate == 1.0:
-            return CopyThread(source_path, target_path, self.parent)
-
-        ffmpeg_path = 'ffmpeg/bin/ffmpeg.exe'
-        command = [ffmpeg_path, '-i', source_path]
-        video_filters, audio_filters = self._build_rate_filters(playback_rate)
-        if video_filters: command.extend(['-filter:v', ",".join(video_filters)])
-        if audio_filters: command.extend(['-filter:a', ",".join(audio_filters)])
-        command.extend(['-c:v', 'libx264', '-crf', '18', '-preset', 'medium', '-c:a', 'aac', '-b:a', '192k', '-y', target_path])
-
-        return FfmpegThread(command, source_path, self.parent)
-
-    def save_compressed(self, source_path, target_path, quality=5, playback_rate=1.0):
-        crf = 28 - quality
-        ffmpeg_path = 'ffmpeg/bin/ffmpeg.exe'
-        command = [ffmpeg_path, '-i', source_path]
-        video_filters, audio_filters = self._build_rate_filters(playback_rate)
-        if video_filters: command.extend(['-filter:v', ",".join(video_filters)])
-        if audio_filters: command.extend(['-filter:a', ",".join(audio_filters)])
-        command.extend(['-c:v', 'libx264', '-crf', str(crf), '-preset', 'medium', '-c:a', 'aac', '-b:a', '128k', '-y', target_path])
-
-        return FfmpegThread(command, source_path, self.parent)
-
-    def _build_rate_filters(self, playback_rate):
-        video_filters = []
-        audio_filters = []
-        if playback_rate != 1.0 and playback_rate > 0:
-            video_filters.append(f"setpts={1.0/playback_rate}*PTS")
-            atempo_filters = []
-            rate = playback_rate
-            while rate > 100.0:
-                atempo_filters.append("atempo=100.0")
-                rate /= 100.0
-            while rate < 0.5 and rate > 0:
-                atempo_filters.append("atempo=0.5")
-                rate /= 0.5
-            if rate != 1.0:
-                atempo_filters.append(f"atempo={rate}")
-            if atempo_filters:
-                audio_filters.append(','.join(atempo_filters))
-        return video_filters, audio_filters

--- a/src/ui/VideoSaveOptionsDialog.py
+++ b/src/ui/VideoSaveOptionsDialog.py
@@ -66,20 +66,20 @@ class VideoSaveOptionsDialog(QDialog):
         self.compressionGroup.setLayout(compressLayout)
         layout.addWidget(self.compressionGroup)
 
-        # Slow Motion options group
-        self.slowMotionGroup = QGroupBox("Effetto Slow Motion (Optical Flow)")
-        self.slowMotionGroup.setCheckable(True)
-        self.slowMotionGroup.setChecked(False)
-        slowMotionLayout = QHBoxLayout(self.slowMotionGroup)
+        # Frame Interpolation options group
+        self.interpolationGroup = QGroupBox("Frame Interpolation (Optical Flow)")
+        self.interpolationGroup.setCheckable(True)
+        self.interpolationGroup.setChecked(False)
+        interpolationLayout = QHBoxLayout(self.interpolationGroup)
 
-        slowMotionLayout.addWidget(QLabel("Fattore di rallentamento:"))
-        self.slowMotionFactorSpinBox = QSpinBox()
-        self.slowMotionFactorSpinBox.setRange(2, 5)
-        self.slowMotionFactorSpinBox.setValue(2)
-        self.slowMotionFactorSpinBox.setSuffix("x")
-        slowMotionLayout.addWidget(self.slowMotionFactorSpinBox)
-        slowMotionLayout.addStretch()
-        layout.addWidget(self.slowMotionGroup)
+        interpolationLayout.addWidget(QLabel("Fattore di interpolazione:"))
+        self.interpolationFactorSpinBox = QSpinBox()
+        self.interpolationFactorSpinBox.setRange(2, 5)
+        self.interpolationFactorSpinBox.setValue(2)
+        self.interpolationFactorSpinBox.setSuffix("x")
+        interpolationLayout.addWidget(self.interpolationFactorSpinBox)
+        interpolationLayout.addStretch()
+        layout.addWidget(self.interpolationGroup)
 
         # Enable/disable options based on selection
         self.originalRadio.toggled.connect(self.update_options_state)
@@ -103,8 +103,8 @@ class VideoSaveOptionsDialog(QDialog):
             'use_compression': self.compressedRadio.isChecked(),
             'compression_quality': self.qualitySlider.value(),
             'save_with_speed': self.saveWithPlaybackSpeedCheck.isChecked(),
-            'use_slow_motion': self.slowMotionGroup.isChecked(),
-            'slow_motion_factor': self.slowMotionFactorSpinBox.value()
+            'use_interpolation': self.interpolationGroup.isChecked(),
+            'interpolation_factor': self.interpolationFactorSpinBox.value()
         }
 
     def get_file_size_info(self):


### PR DESCRIPTION
This feature introduces a new, independent option in the video saving dialog to enable frame interpolation using OpenCV's Optical Flow. This allows users to increase the frame rate of a video, making motion smoother, without necessarily changing the playback speed.

- The `VideoSaveOptionsDialog` now has a separate, checkable group box for "Frame Interpolation (Optical Flow)" with a `QSpinBox` to set the interpolation factor.
- `VideoSaver.py` has been refactored to use a single, unified `VideoProcessingThread`.
- This new thread implements a two-stage pipeline:
  1. An optional interpolation stage using `cv2.calcOpticalFlowFarneback` to create a temporary high-FPS video.
  2. An FFmpeg stage that takes the new video as input to apply any speed changes or compression, while correctly merging the audio from the original source.
- This design allows frame interpolation and speed changes to be used independently or combined for high-quality, smooth slow-motion effects.
- The main `saveVideoAs` method in `TGeniusAI.py` has been updated to use this new, flexible saving mechanism.