### PR TITLE
fix: Correct font size rendering in video overlays

### DIFF
--- a/src/TGeniusAI.py
+++ b/src/TGeniusAI.py
@@ -6717,12 +6717,6 @@ class VideoAudioManager(QMainWindow):
             start_time = self.player.position() / 1000.0
             self.show_status_message(f"Adding overlay at current position: {start_time:.2f}s")
 
-        if media_data['type'] == 'text':
-            points = media_data['fontsize']
-            # Convert points to pixels (assuming 96 DPI)
-            pixels = int(points * 96 / 72)
-            media_data['fontsize'] = pixels
-
         thread = MediaOverlayThread(
             base_video_path=self.videoPathLineEdit,
             media_data=media_data,

--- a/src/ui/AddMediaDialog.py
+++ b/src/ui/AddMediaDialog.py
@@ -1,6 +1,6 @@
 import os
 from PyQt6.QtCore import Qt, pyqtSignal, QSize
-from PyQt6.QtGui import QFont, QColor, QPainter, QPixmap
+from PyQt6.QtGui import QFont, QColor, QPainter, QPixmap, QFontInfo
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QTabWidget, QWidget, QFormLayout, QLineEdit,
     QSpinBox, QPushButton, QDialogButtonBox, QColorDialog, QFontDialog,
@@ -358,7 +358,7 @@ class AddMediaDialog(QDialog):
                 "type": "text",
                 "text": self.text_input.text(),
                 "font": self.current_font.family(),
-                "fontsize": self.current_font.pointSize(),
+                "fontsize": QFontInfo(self.current_font).pixelSize(),
                 "color": self.current_color.name(),
                 "position": (self.pos_x_spinbox.value(), self.pos_y_spinbox.value()),
                 "duration": self.duration_spinbox_text.value(),


### PR DESCRIPTION
This commit fixes a bug where the font size selected in the "Add Media/Text" dialog was not accurately reflected in the final rendered video.

The issue was caused by a discrepancy between the font size units used by the UI (points) and the rendering engine (pixels).

The fix involves two key changes:
1.  In `AddMediaDialog.py`, the `get_media_data` method now uses `QFontInfo(self.current_font).pixelSize()` to retrieve the exact font size in pixels as it is rendered in the preview.
2.  The manual point-to-pixel conversion logic in `TGeniusAI.py` has been removed, as it was incorrect and is no longer necessary.

This ensures that the font size in the final video is identical to the size shown in the live preview, providing a consistent and accurate user experience.