### PR TITLE
Fix: Use pointSize for consistent font rendering in overlays

### DIFF
--- a/src/ui/AddMediaDialog.py
+++ b/src/ui/AddMediaDialog.py
@@ -358,7 +358,7 @@ class AddMediaDialog(QDialog):
                 "type": "text",
                 "text": self.text_input.text(),
                 "font": self.current_font.family(),
-                "fontsize": QFontInfo(self.current_font).pixelSize(),
+                "fontsize": self.current_font.pointSize(),
                 "color": self.current_color.name(),
                 "position": (self.pos_x_spinbox.value(), self.pos_y_spinbox.value()),
                 "duration": self.duration_spinbox_text.value(),


### PR DESCRIPTION
The `AddMediaDialog` was incorrectly sending the font size to the `MediaOverlayThread` in pixels (`pixelSize`) instead of points. The rendering engine, which uses Pillow, expected the size in points, causing a discrepancy between the selected font size and the final rendered text in the video.

This commit corrects the issue by changing `QFontInfo().pixelSize()` to `current_font.pointSize()` in the `get_media_data` method. This ensures that the font size is passed in the correct units (points), resulting in the text overlay appearing at the size selected by the user, regardless of screen resolution or DPI settings.